### PR TITLE
feat: add custom pluggable widget AIGC skill

### DIFF
--- a/.claude/skills/mendix/README.md
+++ b/.claude/skills/mendix/README.md
@@ -59,6 +59,7 @@ Page-specific patterns:
 | Skill | Purpose | Use When |
 |-------|---------|----------|
 | [generate-domain-model.md](generate-domain-model.md) | Complete domain model generation | Generating full domain models |
+| [create-custom-widget.md](create-custom-widget.md) | Custom pluggable widget AIGC | Creating custom React widgets from scratch |
 | [debug-bson.md](debug-bson.md) | BSON debugging | Troubleshooting SDK issues |
 
 ---
@@ -83,6 +84,8 @@ Load skills based on the task:
 | "Change widgets in bulk" | `bulk-widget-updates.md` |
 | "Reuse widgets across pages" | `fragments.md` |
 | "Define a fragment" | `fragments.md` |
+| "Create custom widget" | `create-custom-widget.md` |
+| "Build a pluggable widget" | `create-custom-widget.md` |
 
 ### For Error Recovery
 

--- a/.claude/skills/mendix/create-custom-widget.md
+++ b/.claude/skills/mendix/create-custom-widget.md
@@ -1,0 +1,417 @@
+# Create Custom Pluggable Widget
+
+Build a Mendix pluggable widget from scratch using React + TypeScript. Produces a `.mpk` file ready for Studio Pro.
+
+## Prerequisites
+
+- Node.js >= 16
+- npm
+
+## Step 1: Scaffold the Project
+
+Create a directory and generate all source files. Use PascalCase for the widget name.
+
+```bash
+mkdir -p <WidgetName>/src/components <WidgetName>/src/ui
+```
+
+### package.json
+
+```json
+{
+  "name": "<widget-name>",
+  "widgetName": "<WidgetName>",
+  "version": "1.0.0",
+  "description": "<description>",
+  "license": "Apache-2.0",
+  "config": {
+    "projectPath": "./tests/testProject",
+    "mendixHost": "http://localhost:8080",
+    "developmentPort": 3000
+  },
+  "packagePath": "com.example.widgets",
+  "scripts": {
+    "dev": "pluggable-widgets-tools start:web",
+    "build": "pluggable-widgets-tools build:web",
+    "lint": "pluggable-widgets-tools lint",
+    "lint:fix": "pluggable-widgets-tools lint:fix"
+  },
+  "devDependencies": {
+    "@mendix/pluggable-widgets-tools": "^11.6.0",
+    "@types/big.js": "^6.0.2"
+  },
+  "dependencies": {
+    "classnames": "^2.2.6"
+  },
+  "resolutions": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0"
+  },
+  "overrides": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0"
+  }
+}
+```
+
+**Naming rules:**
+- `name`: kebab-case (npm package name)
+- `widgetName`: PascalCase (matches .xml and .tsx filename)
+- `packagePath`: reverse domain, dot-separated (e.g. `com.example.widgets`)
+
+### tsconfig.json
+
+```json
+{
+  "extends": "./node_modules/@mendix/pluggable-widgets-tools/configs/tsconfig.base.json"
+}
+```
+
+### src/package.xml
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<package xmlns="http://www.mendix.com/package/1.0/">
+    <clientModule name="<WidgetName>" version="1.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
+        <widgetFiles>
+            <widgetFile path="<WidgetName>.xml"/>
+        </widgetFiles>
+        <files>
+            <file path="com/example/widgets/<widgetname>"/>
+        </files>
+    </clientModule>
+</package>
+```
+
+The `<file path>` must match `packagePath` + lowercase widget name, with dots replaced by `/`. For example, for `HelloWorld` with `packagePath=com.example.widgets`, the path is `com/example/widgets/helloworld`.
+
+## Step 2: Define Widget Properties (widget.xml)
+
+### src/\<WidgetName\>.xml
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<widget id="com.example.widgets.<widgetname>.<WidgetName>"
+        pluginWidget="true"
+        needsEntityContext="true"
+        offlineCapable="true"
+        supportedPlatform="Web"
+        xmlns="http://www.mendix.com/widget/1.0/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
+    <name><Widget Name></name>
+    <description><description></description>
+    <icon/>
+    <properties>
+        <propertyGroup caption="General">
+            <!-- Add properties here -->
+        </propertyGroup>
+    </properties>
+</widget>
+```
+
+The `id` attribute must be `<packagePath>.<widgetname>.<WidgetName>` — the second-to-last segment is the **lowercase** widget name, which becomes the JS subdirectory. This must match the `<file path>` in `package.xml`.
+
+Set `needsEntityContext="true"` when the widget needs entity data. Set to `"false"` for standalone widgets.
+
+### Property Type Reference
+
+| XML Type | Mendix Type | Use Case | Example |
+|----------|------------|----------|---------|
+| `string` | Static text | Labels, titles | `<property key="title" type="string"><caption>Title</caption></property>` |
+| `boolean` | Toggle | Show/hide, enable | `<property key="showHeader" type="boolean" defaultValue="true"><caption>Show header</caption></property>` |
+| `integer` | Number | Counts, sizes | `<property key="columns" type="integer" defaultValue="3"><caption>Columns</caption></property>` |
+| `decimal` | Decimal | Measurements | `<property key="opacity" type="decimal" defaultValue="1.0"><caption>Opacity</caption></property>` |
+| `enumeration` | Enum choice | Mode selection | See below |
+| `expression` | Dynamic value | Computed text | `<property key="label" type="expression" defaultValue=""><caption>Label</caption><returnType type="String"/></property>` |
+| `textTemplate` | Template text | Formatted text with params | See below |
+| `attribute` | Entity attribute | Data binding | See below |
+| `datasource` | List data source | Lists, grids | `<property key="dataSource" type="datasource" isList="true"><caption>Data source</caption></property>` |
+| `widgets` | Child widgets | Content slots | `<property key="content" type="widgets" required="false"><caption>Content</caption></property>` |
+| `action` | On-click action | Buttons, links | `<property key="onClick" type="action"><caption>On click</caption></property>` |
+| `icon` | Icon | Decorative | `<property key="icon" type="icon" required="false"><caption>Icon</caption></property>` |
+| `image` | Image | Avatar, logo | `<property key="image" type="image" required="false"><caption>Image</caption></property>` |
+| `object` | Compound | Complex config | See below |
+
+### Enumeration Example
+
+```xml
+<property key="alignment" type="enumeration" defaultValue="center">
+    <caption>Alignment</caption>
+    <description/>
+    <enumerationValues>
+        <enumerationValue key="left">Left</enumerationValue>
+        <enumerationValue key="center">Center</enumerationValue>
+        <enumerationValue key="right">Right</enumerationValue>
+    </enumerationValues>
+</property>
+```
+
+### Attribute Binding Example
+
+```xml
+<property key="value" type="attribute">
+    <caption>Value</caption>
+    <description>The attribute to display</description>
+    <attributeTypes>
+        <attributeType name="String"/>
+        <attributeType name="Integer"/>
+        <attributeType name="Decimal"/>
+    </attributeTypes>
+</property>
+```
+
+### TextTemplate Example
+
+```xml
+<property key="displayText" type="textTemplate">
+    <caption>Display text</caption>
+    <description/>
+    <translations>
+        <translation lang="en_US">Default text</translation>
+    </translations>
+</property>
+```
+
+### Object (Compound) Example — e.g. column definitions
+
+```xml
+<property key="columns" type="object" isList="true">
+    <caption>Columns</caption>
+    <description/>
+    <properties>
+        <propertyGroup caption="Column">
+            <property key="header" type="textTemplate">
+                <caption>Header</caption>
+                <translations><translation lang="en_US">Column</translation></translations>
+            </property>
+            <property key="attribute" type="attribute" dataSource="dataSource">
+                <caption>Attribute</caption>
+                <attributeTypes>
+                    <attributeType name="String"/>
+                    <attributeType name="Integer"/>
+                </attributeTypes>
+            </property>
+            <property key="width" type="integer" defaultValue="100">
+                <caption>Width (px)</caption>
+            </property>
+        </propertyGroup>
+    </properties>
+</property>
+```
+
+Note: `dataSource="dataSource"` links the attribute picker to the `dataSource` property.
+
+### Property Groups
+
+Use nested `<propertyGroup>` for Studio Pro tab organization:
+
+```xml
+<properties>
+    <propertyGroup caption="General">
+        <!-- main properties -->
+    </propertyGroup>
+    <propertyGroup caption="Appearance">
+        <!-- style properties -->
+    </propertyGroup>
+    <propertyGroup caption="Events">
+        <!-- action properties -->
+    </propertyGroup>
+</properties>
+```
+
+## Step 3: Write the Entry Component
+
+### src/\<WidgetName\>.tsx
+
+```tsx
+import { ReactElement } from "react";
+import { <WidgetName>ContainerProps } from "../typings/<WidgetName>Props";
+import { MyComponent } from "./components/MyComponent";
+import "./ui/<WidgetName>.css";
+
+export function <WidgetName>(props: <WidgetName>ContainerProps): ReactElement {
+    // Map Mendix props to React component props
+    return <MyComponent {...relevantProps} />;
+}
+```
+
+The `typings/<WidgetName>Props.d.ts` file is **auto-generated** by the build tool from the `.xml` definition. Do NOT create it manually.
+
+### Key Mendix Prop Patterns
+
+```tsx
+// String property
+props.title  // string
+
+// Boolean property
+props.showHeader  // boolean
+
+// Expression property
+props.label?.value  // string | undefined (use .value to get resolved text)
+
+// Attribute property (read)
+props.value?.displayValue  // string
+props.value?.value  // actual typed value
+
+// Attribute property (write)
+props.value?.setValue(newValue)
+
+// TextTemplate property
+props.displayText?.value  // string (resolved template)
+
+// Action property
+props.onClick?.canExecute  // boolean
+props.onClick?.execute()   // trigger the action
+
+// Datasource property
+props.dataSource?.items  // ObjectItem[] | undefined
+props.dataSource?.status  // "available" | "loading"
+
+// Widgets property (content slot)
+props.content  // ReactNode
+
+// Icon property
+import { Icon } from "mendix/components/web/Icon";
+<Icon icon={props.icon} />
+
+// Object list property (e.g. columns)
+props.columns  // Array<{ header, attribute, width }>
+// Access attribute value for a specific item:
+props.columns[0].attribute?.get(item)?.displayValue
+```
+
+## Step 4: Write the React Component
+
+### src/components/MyComponent.tsx
+
+Keep the component pure React — no Mendix API dependencies. This makes it testable and reusable.
+
+```tsx
+import { ReactElement } from "react";
+import classNames from "classnames";
+
+export interface MyComponentProps {
+    title: string;
+    value?: string;
+    className?: string;
+}
+
+export function MyComponent({ title, value, className }: MyComponentProps): ReactElement {
+    return (
+        <div className={classNames("widget-my-component", className)}>
+            <h3>{title}</h3>
+            {value && <p>{value}</p>}
+        </div>
+    );
+}
+```
+
+## Step 5: Editor Config (optional but recommended)
+
+### src/\<WidgetName\>.editorConfig.ts
+
+Controls how the widget appears in Studio Pro's design mode:
+
+```ts
+import { <WidgetName>PreviewProps } from "../typings/<WidgetName>Props";
+
+export type Properties = PropertyGroup[];
+type PropertyGroup = {
+    caption: string;
+    propertyGroups?: PropertyGroup[];
+    properties?: Property[];
+};
+type Property = {
+    key: string;
+    caption: string;
+    description?: string;
+};
+
+export function getProperties(
+    _values: <WidgetName>PreviewProps,
+    defaultProperties: Properties
+): Properties {
+    return defaultProperties;
+}
+```
+
+## Step 6: CSS Styles
+
+### src/ui/\<WidgetName\>.css
+
+```css
+.widget-<widget-name> {
+    /* widget styles */
+}
+```
+
+Use a `.widget-<widget-name>` prefix to avoid CSS collisions.
+
+## Step 7: Build
+
+```bash
+cd <widget-dir>
+npm install
+npm run build
+```
+
+Output: `dist/<version>/com.example.widgets.<WidgetName>.mpk`
+
+## Step 8: Install to Mendix Project
+
+```bash
+cp dist/*/*.mpk /path/to/mendix-project/widgets/
+```
+
+Then open/reload the project in Studio Pro.
+
+## Common Widget Patterns
+
+### KPI Card
+
+Properties: `title (string)`, `value (expression/String)`, `icon (icon)`, `trend (enumeration: up/down/neutral)`, `onClick (action)`
+
+### Chart Wrapper
+
+Properties: `dataSource (datasource)`, `valueAttr (attribute/Decimal)`, `labelAttr (attribute/String)`, `chartType (enumeration)`, `height (integer)`
+
+Wrap a charting library (Chart.js, Recharts) inside the component.
+
+### Custom Input
+
+Properties: `value (attribute/String, writable)`, `placeholder (string)`, `onChange (action)`, `validation (expression/String)`
+
+Set `needsEntityContext="true"`. Use `props.value.setValue()` for two-way binding.
+
+### Layout Component
+
+Properties: `content (widgets)`, `columns (integer)`, `gap (integer)`
+
+Set `needsEntityContext="false"`. Render children via `{props.content}`.
+
+## Checklist Before Build
+
+- [ ] `id` in `.xml` matches `packagePath.WidgetName`
+- [ ] `<name>` in package.xml matches `.xml` filename (without extension)
+- [ ] `<file path>` in package.xml matches packagePath with `/` separators
+- [ ] Entry `.tsx` exports a function with the exact widget name
+- [ ] CSS file imported in entry `.tsx`
+- [ ] `needsEntityContext` matches whether entity data is needed
+- [ ] No manual `Props.d.ts` file (auto-generated by build tool)
+- [ ] All `expression` properties have `<returnType>`
+- [ ] All `attribute` properties list valid `<attributeType>` entries
+- [ ] `object` properties with attributes set `dataSource` reference
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Cannot find module '../typings/...'` | Haven't built yet | Run `npm run build` first, types are generated |
+| `Widget not showing in Studio Pro` | Wrong `id` in XML | Ensure `id="packagePath.WidgetName"` |
+| `CE0463 widget definition changed` | Property mismatch | Ensure XML and component props match |
+| `pluginWidget must be true` | Missing attribute | Add `pluginWidget="true"` to `<widget>` |

--- a/cmd/mxcli/skills/README.md
+++ b/cmd/mxcli/skills/README.md
@@ -59,6 +59,7 @@ Page-specific patterns:
 | Skill | Purpose | Use When |
 |-------|---------|----------|
 | [generate-domain-model.md](generate-domain-model.md) | Complete domain model generation | Generating full domain models |
+| [create-custom-widget.md](create-custom-widget.md) | Custom pluggable widget AIGC | Creating custom React widgets from scratch |
 | [debug-bson.md](debug-bson.md) | BSON debugging | Troubleshooting SDK issues |
 
 ---
@@ -83,6 +84,8 @@ Load skills based on the task:
 | "Change widgets in bulk" | `bulk-widget-updates.md` |
 | "Reuse widgets across pages" | `fragments.md` |
 | "Define a fragment" | `fragments.md` |
+| "Create custom widget" | `create-custom-widget.md` |
+| "Build a pluggable widget" | `create-custom-widget.md` |
 
 ### For Error Recovery
 

--- a/docs/plans/2026-03-27-custom-widget-aigc-design.md
+++ b/docs/plans/2026-03-27-custom-widget-aigc-design.md
@@ -1,0 +1,49 @@
+# Custom Widget AIGC Design
+
+## Goal
+
+Provide a skill file that teaches Claude to autonomously create Mendix pluggable widgets from natural language descriptions, producing a ready-to-use `.mpk` file.
+
+## Flow
+
+```
+User describes widget → Claude generates source files → npm install → npm run build → .mpk output
+```
+
+## Key Decisions
+
+1. **No Yeoman generator** — direct file generation is more controllable for AI
+2. **TypeScript + Function Components** — modern, type-safe, matches Mendix best practices
+3. **`@mendix/pluggable-widgets-tools ^11.6`** — official build toolchain
+4. **Skill-only deliverable** — no Go code changes needed, just `.claude/skills/mendix/create-custom-widget.md`
+
+## Generated Project Structure
+
+```
+<widget-name>/
+├── package.json
+├── tsconfig.json
+├── src/
+│   ├── package.xml
+│   ├── <Name>.xml           # widget property definitions
+│   ├── <Name>.tsx            # entry point (Mendix API → React)
+│   ├── <Name>.editorConfig.ts
+│   ├── components/
+│   │   └── <Component>.tsx   # actual React UI
+│   └── ui/
+│       └── <Name>.css
+```
+
+## Skill Content Outline
+
+1. **Prerequisites** — Node.js >= 16, npm
+2. **Property Type Reference** — all XML property types with examples
+3. **File Templates** — exact content for each generated file
+4. **Common Widget Patterns** — KPI card, chart wrapper, custom input, layout component
+5. **Build & Integration** — npm install, npm run build, copy .mpk to widgets/
+6. **Naming Conventions** — widget ID format, package path conventions
+7. **Checklist** — pre-build validation steps
+
+## Integration with mxcli
+
+The skill is synced to user projects via `mxcli init` (already handled by the existing skill sync system in `reference/mendix-repl/templates/.claude/skills/`).


### PR DESCRIPTION
## Summary

- Add skill file (`.claude/skills/mendix/create-custom-widget.md`) that teaches Claude to autonomously scaffold, build, and install Mendix pluggable widgets from natural language descriptions
- Fix critical widget id namespace format: must include lowercase widget name segment (e.g. `com.example.widgets.helloworld.HelloWorld`) to match the JS subdirectory the build tool creates, preventing 404 at runtime
- Add design document explaining key decisions (no Yeoman, TypeScript + Function Components, official toolchain)

## Test plan

- [x] Built HelloWorld widget with corrected id format — MPK structure matches working Mendix widgets (Tooltip, Combobox, etc.)
- [x] Verified JS path in MPK (`com/example/widgets/helloworld/HelloWorld.js`) aligns with `<file path>` in package.xml
- [x] Compared against baseline Tooltip widget MPK from GenAIDemo project
- [x] Deploy rebuilt MPK to Studio Pro and confirm widget loads without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)