### PR TITLE
fix(catalog): recurse into loop bodies when extracting references

### DIFF
--- a/mdl/catalog/builder_references.go
+++ b/mdl/catalog/builder_references.go
@@ -30,6 +30,26 @@ const (
 	RefKindMenuItem   = "menu_item"  // Navigation menu item page reference
 )
 
+// collectActionActivities returns all ActionActivity objects from an ObjectCollection,
+// recursing into LoopedActivity bodies to find nested actions.
+func collectActionActivities(oc *microflows.MicroflowObjectCollection) []*microflows.ActionActivity {
+	if oc == nil {
+		return nil
+	}
+	var result []*microflows.ActionActivity
+	for _, obj := range oc.Objects {
+		switch o := obj.(type) {
+		case *microflows.ActionActivity:
+			if o.Action != nil {
+				result = append(result, o)
+			}
+		case *microflows.LoopedActivity:
+			result = append(result, collectActionActivities(o.ObjectCollection)...)
+		}
+	}
+	return result
+}
+
 // buildReferences extracts cross-references from all documents.
 // This is only run in full mode as it requires parsing all documents.
 func (b *Builder) buildReferences() error {
@@ -66,12 +86,7 @@ func (b *Builder) buildReferences() error {
 			continue
 		}
 
-		for _, obj := range mf.ObjectCollection.Objects {
-			act, ok := obj.(*microflows.ActionActivity)
-			if !ok || act.Action == nil {
-				continue
-			}
-
+		for _, act := range collectActionActivities(mf.ObjectCollection) {
 			switch a := act.Action.(type) {
 			case *microflows.MicroflowCallAction:
 				if a.MicroflowCall != nil && a.MicroflowCall.Microflow != "" {

--- a/mdl/catalog/builder_references_test.go
+++ b/mdl/catalog/builder_references_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"testing"
+
+	"github.com/mendixlabs/mxcli/model"
+	"github.com/mendixlabs/mxcli/sdk/microflows"
+)
+
+func newAction(id string, action microflows.MicroflowAction) *microflows.ActionActivity {
+	return &microflows.ActionActivity{
+		BaseActivity: microflows.BaseActivity{
+			BaseMicroflowObject: microflows.BaseMicroflowObject{
+				BaseElement: model.BaseElement{ID: model.ID(id)},
+			},
+		},
+		Action: action,
+	}
+}
+
+func newLoop(id string, children ...microflows.MicroflowObject) *microflows.LoopedActivity {
+	return &microflows.LoopedActivity{
+		BaseMicroflowObject: microflows.BaseMicroflowObject{
+			BaseElement: model.BaseElement{ID: model.ID(id)},
+		},
+		ObjectCollection: &microflows.MicroflowObjectCollection{Objects: children},
+	}
+}
+
+func TestCollectActionActivities_TopLevelOnly(t *testing.T) {
+	oc := &microflows.MicroflowObjectCollection{
+		Objects: []microflows.MicroflowObject{
+			newAction("a1", &microflows.MicroflowCallAction{}),
+			newAction("a2", &microflows.CreateObjectAction{}),
+		},
+	}
+	result := collectActionActivities(oc)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 activities, got %d", len(result))
+	}
+}
+
+func TestCollectActionActivities_InsideLoop(t *testing.T) {
+	oc := &microflows.MicroflowObjectCollection{
+		Objects: []microflows.MicroflowObject{
+			newLoop("loop1",
+				newAction("inner1", &microflows.MicroflowCallAction{}),
+				newAction("inner2", &microflows.ShowPageAction{}),
+			),
+			newAction("outer1", &microflows.RetrieveAction{}),
+		},
+	}
+	result := collectActionActivities(oc)
+	if len(result) != 3 {
+		t.Fatalf("expected 3 activities (2 inside loop + 1 outside), got %d", len(result))
+	}
+}
+
+func TestCollectActionActivities_NestedLoops(t *testing.T) {
+	oc := &microflows.MicroflowObjectCollection{
+		Objects: []microflows.MicroflowObject{
+			newLoop("outer-loop",
+				newLoop("inner-loop",
+					newAction("deep", &microflows.MicroflowCallAction{}),
+				),
+			),
+		},
+	}
+	result := collectActionActivities(oc)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 deeply nested activity, got %d", len(result))
+	}
+	if result[0].ID != "deep" {
+		t.Errorf("expected activity ID 'deep', got %q", result[0].ID)
+	}
+}
+
+func TestCollectActionActivities_NilCollection(t *testing.T) {
+	result := collectActionActivities(nil)
+	if result != nil {
+		t.Fatalf("expected nil for nil collection, got %v", result)
+	}
+}
+
+func TestCollectActionActivities_SkipsNilActions(t *testing.T) {
+	oc := &microflows.MicroflowObjectCollection{
+		Objects: []microflows.MicroflowObject{
+			newAction("no-action", nil),
+			newAction("has-action", &microflows.MicroflowCallAction{}),
+		},
+	}
+	result := collectActionActivities(oc)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 activity (skipping nil action), got %d", len(result))
+	}
+}


### PR DESCRIPTION
## Summary

- `SHOW CALLEES/REFERENCES` missed microflow calls, entity creates, retrieves, and page shows inside `LOOP` bodies
- Root cause: `buildReferences()` in `builder_references.go` only iterated top-level `ObjectCollection.Objects` without recursing into `LoopedActivity.ObjectCollection`
- Extract `collectActionActivities()` helper that recursively collects all `ActionActivity` objects from nested loop bodies (including deeply nested loops)

## Regarding issue #39

The issue reports two problems:
1. **DESCRIBE MICROFLOW missing loop body** — investigation shows this is **already implemented** (`emitLoopBody()` in `cmd_microflows_show_helpers.go:431-493`) with passing roundtrip test (`TestRoundtripMicroflow_LoopWithBody`). The reporter's specific case may involve a different edge case — requesting their project file to reproduce.
2. **SHOW CALLEES missing loop body calls** — **confirmed bug, fixed in this PR**

Partially fixes #39

## Test plan

- [x] Unit tests for `collectActionActivities()`: top-level, inside loop, nested loops, nil collection, nil actions
- [x] All existing catalog tests pass
- [x] `make build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)