### PR TITLE
fix: improve data container context hints and LSP completion

### DIFF
--- a/cmd/mxcli/lsp_completion.go
+++ b/cmd/mxcli/lsp_completion.go
@@ -33,7 +33,7 @@ func (s *mdlServer) Completion(ctx context.Context, params *protocol.CompletionP
 
 	// Check if typing a $ variable reference inside page/snippet context
 	if strings.Contains(linePrefix, "$") {
-		varItems := s.variableCompletionItems(text, linePrefix)
+		varItems := s.variableCompletionItems(text, linePrefix, int(params.Position.Line))
 		if len(varItems) > 0 {
 			return &protocol.CompletionList{
 				IsIncomplete: false,
@@ -373,9 +373,10 @@ func objectTypeToCompletionKind(objectType string) (protocol.CompletionItemKind,
 }
 
 // variableCompletionItems returns completion items for $ variable references.
-// It suggests $currentObject (common in data containers) and any page parameters
-// found in the document's CREATE PAGE Params declaration.
-func (s *mdlServer) variableCompletionItems(docText string, linePrefix string) []protocol.CompletionItem {
+// It suggests $currentObject (with entity type from enclosing data container) and
+// any page parameters found in the document's CREATE PAGE Params declaration.
+// cursorLine is the 0-based line number of the cursor position.
+func (s *mdlServer) variableCompletionItems(docText string, linePrefix string, cursorLine int) []protocol.CompletionItem {
 	// Extract the partial after the last $ to filter suggestions
 	lastDollar := strings.LastIndex(linePrefix, "$")
 	partial := ""
@@ -385,13 +386,36 @@ func (s *mdlServer) variableCompletionItems(docText string, linePrefix string) [
 
 	var items []protocol.CompletionItem
 
-	// Always suggest $currentObject — it's the most common data container variable
+	// Scan upward from cursor to find enclosing data container context
+	entityType, widgetName := scanEnclosingDataContainer(docText, cursorLine)
+
+	// Suggest $currentObject with entity type if found
 	if partial == "" || strings.HasPrefix("CURRENTOBJECT", partial) {
+		detail := "Current object from enclosing data container"
+		if entityType != "" {
+			detail = entityType
+		}
 		items = append(items, protocol.CompletionItem{
 			Label:  "$currentObject",
 			Kind:   protocol.CompletionItemKindVariable,
-			Detail: "Current object from enclosing data container",
+			Detail: detail,
 		})
+	}
+
+	// Suggest $widgetName (selection) for list containers
+	if widgetName != "" {
+		wNameUpper := strings.ToUpper(widgetName)
+		if partial == "" || strings.HasPrefix(wNameUpper, partial) {
+			detail := "Selection from list container"
+			if entityType != "" {
+				detail = entityType + " (selection)"
+			}
+			items = append(items, protocol.CompletionItem{
+				Label:  "$" + widgetName,
+				Kind:   protocol.CompletionItemKindVariable,
+				Detail: detail,
+			})
+		}
 	}
 
 	// Extract page parameter names from CREATE PAGE ... Params: { $Name: Type, ... }
@@ -409,13 +433,133 @@ func (s *mdlServer) variableCompletionItems(docText string, linePrefix string) [
 	return items
 }
 
-// extractPageParamNames extracts parameter names from CREATE PAGE ... Params: { $Name: Type } declarations.
+// scanEnclosingDataContainer scans upward from cursorLine to find the nearest
+// enclosing data container widget and its entity type.
+// Returns (entityType, widgetName) where widgetName is set for list containers.
+// Best-effort: uses brace matching and keyword scanning (Enclosing Scope Scanning pattern).
+func scanEnclosingDataContainer(text string, cursorLine int) (string, string) {
+	lines := strings.Split(text, "\n")
+	if cursorLine >= len(lines) {
+		return "", ""
+	}
+
+	// Track brace nesting depth as we scan upward
+	depth := 0
+	for i := cursorLine; i >= 0; i-- {
+		line := lines[i]
+		// Count braces on this line (right to left for correct nesting)
+		for j := len(line) - 1; j >= 0; j-- {
+			switch line[j] {
+			case '}':
+				depth++
+			case '{':
+				depth--
+			}
+		}
+
+		// At depth < 0, we've found an opening brace that encloses the cursor
+		if depth < 0 {
+			trimmed := strings.TrimSpace(line)
+			upper := strings.ToUpper(trimmed)
+
+			// Check for data container keywords
+			entityType, widgetName, isList := extractContainerInfo(upper, trimmed)
+			if entityType != "" {
+				if isList {
+					return entityType, widgetName
+				}
+				return entityType, ""
+			}
+			// Reset depth — we passed through this opening brace but it wasn't a data container
+			depth = 0
+		}
+	}
+	return "", ""
+}
+
+// extractContainerInfo extracts entity type and widget name from a data container line.
+// upperLine is the uppercase version, originalLine preserves case for widget name extraction.
+// Returns (entityType, widgetName, isList).
+func extractContainerInfo(upperLine string, originalLine string) (string, string, bool) {
+	// Patterns: DATAVIEW name (DataSource: ...) {
+	//           LISTVIEW name (DataSource: DATABASE FROM Module.Entity ...) {
+	//           DATAGRID name (DataSource: DATABASE FROM Module.Entity ...) {
+	//           GALLERY name (DataSource: DATABASE FROM Module.Entity ...) {
+	type containerPattern struct {
+		keyword string
+		isList  bool
+	}
+	patterns := []containerPattern{
+		{"DATAVIEW ", false},
+		{"LISTVIEW ", true},
+		{"DATAGRID ", true},
+		{"GALLERY ", true},
+	}
+
+	for _, p := range patterns {
+		if !strings.HasPrefix(upperLine, p.keyword) {
+			continue
+		}
+
+		// Extract widget name (first token after keyword)
+		rest := strings.TrimSpace(originalLine[len(p.keyword):])
+		widgetName := ""
+		for j, c := range rest {
+			if c == ' ' || c == '(' || c == '{' {
+				widgetName = rest[:j]
+				break
+			}
+		}
+		if widgetName == "" {
+			widgetName = rest
+		}
+
+		// Extract entity from DataSource (use original case for entity name)
+		entityType := extractEntityFromLine(originalLine)
+		if entityType != "" {
+			return entityType, widgetName, p.isList
+		}
+	}
+	return "", "", false
+}
+
+// extractEntityFromLine extracts the entity type from a DataSource declaration in a line.
+// Preserves original casing of the entity name (e.g., "Sales.Order" not "SALES.ORDER").
+func extractEntityFromLine(line string) string {
+	// Case-insensitive search for "DATABASE FROM" pattern
+	upperLine := strings.ToUpper(line)
+	if idx := strings.Index(upperLine, "DATABASE FROM "); idx >= 0 {
+		rest := strings.TrimSpace(line[idx+len("DATABASE FROM "):])
+		// Entity is the next qualified name (Module.Entity)
+		end := strings.IndexAny(rest, " \t,)}")
+		if end < 0 {
+			end = len(rest)
+		}
+		entity := rest[:end]
+		if strings.Contains(entity, ".") {
+			return entity
+		}
+	}
+	// MICROFLOW/NANOFLOW datasource — entity type not directly available
+	// $ParamName datasource — would need to resolve param type
+	return ""
+}
+
+// extractPageParamNames extracts parameter names from CREATE PAGE/SNIPPET parameter declarations.
+// Best-effort: scans for "$Name: Type" patterns (colon after identifier distinguishes
+// declarations from usage like "DataSource: $Param" or context comments like "$currentObject").
 func extractPageParamNames(text string) []string {
 	var names []string
 	for _, line := range strings.Split(text, "\n") {
 		trimmed := strings.TrimSpace(line)
-		// Look for $ParamName patterns in Params declarations
-		// Format: Params: { $Name: Type } or $Name: Type on separate lines
+		// Skip DECLARE lines (variable declarations, not page params)
+		if strings.HasPrefix(strings.ToUpper(trimmed), "DECLARE") {
+			continue
+		}
+		// Skip comment lines
+		if strings.HasPrefix(trimmed, "--") {
+			continue
+		}
 		idx := 0
 		for idx < len(trimmed) {
 			dollar := strings.Index(trimmed[idx:], "$")
@@ -423,7 +567,7 @@ func extractPageParamNames(text string) []string {
 				break
 			}
 			dollar += idx
-			// Extract the name after $
+			// Extract the identifier after $
 			end := dollar + 1
 			for end < len(trimmed) {
 				c := trimmed[end]
@@ -435,8 +579,10 @@ func extractPageParamNames(text string) []string {
 			}
 			if end > dollar+1 {
 				name := trimmed[dollar+1 : end]
-				// Skip if this looks like a variable declaration (DECLARE) rather than a param
-				if !strings.HasPrefix(strings.ToUpper(trimmed), "DECLARE") {
+				// Only match parameter declarations: "$Name:" followed by a type.
+				// Skip references like "DataSource: $Param" where $ is a value, not a declaration.
+				rest := strings.TrimSpace(trimmed[end:])
+				if strings.HasPrefix(rest, ":") {
 					names = append(names, name)
 				}
 			}

--- a/cmd/mxcli/lsp_completion_test.go
+++ b/cmd/mxcli/lsp_completion_test.go
@@ -32,6 +32,21 @@ func TestExtractPageParamNames(t *testing.T) {
 			text:     "DECLARE $Temp String = '';\n$Order: Mod.Order",
 			expected: []string{"Order"},
 		},
+		{
+			name:     "reject body $currentObject reference",
+			text:     "CREATE PAGE Mod.Page ($Order: Mod.Order) {\n  -- Context: $currentObject (Mod.Order)\n  DATAVIEW dv1 (DataSource: $Order)\n}",
+			expected: []string{"Order"},
+		},
+		{
+			name:     "reject body $var usage without colon",
+			text:     "CREATE PAGE Mod.Page ($Item: Mod.Item) {\n  TEXTBOX t1 (Attribute: $Item/Name)\n}",
+			expected: []string{"Item"},
+		},
+		{
+			name:     "reject comment lines",
+			text:     "-- $FakeParam: NotReal\n$RealParam: Mod.Entity",
+			expected: []string{"RealParam"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -52,9 +67,10 @@ func TestExtractPageParamNames(t *testing.T) {
 
 func TestVariableCompletionItems(t *testing.T) {
 	s := &mdlServer{}
-	docText := "CREATE PAGE Mod.Page (\n  Params: { $Customer: Mod.Customer }\n) {\n  DATAVIEW dv1 (DataSource: $Customer) {\n"
+	docText := "CREATE PAGE Mod.Page (\n  Params: { $Customer: Mod.Customer }\n) {\n  DATAVIEW dv1 (DataSource: $Customer) {\n    TEXTBOX t1 (Attribute: $\n"
 
-	items := s.variableCompletionItems(docText, "$")
+	// Cursor at last line (line 4, 0-based)
+	items := s.variableCompletionItems(docText, "$", 4)
 	if len(items) == 0 {
 		t.Fatal("expected completion items for $ prefix")
 	}
@@ -75,5 +91,81 @@ func TestVariableCompletionItems(t *testing.T) {
 	}
 	if !foundCustomer {
 		t.Error("expected $Customer in completion items")
+	}
+}
+
+func TestVariableCompletionItems_DataGridContext(t *testing.T) {
+	s := &mdlServer{}
+	docText := "CREATE PAGE Mod.Page ($Order: Sales.Order) {\n  DATAGRID dgOrders (DataSource: DATABASE FROM Sales.Order) {\n    COLUMN Name {\n      TEXTBOX t1 (Attribute: $\n"
+
+	// Cursor inside DATAGRID column (line 3)
+	items := s.variableCompletionItems(docText, "$", 3)
+
+	var currentObjDetail string
+	foundSelection := false
+	for _, item := range items {
+		if item.Label == "$currentObject" {
+			currentObjDetail = item.Detail
+		}
+		if item.Label == "$dgOrders" {
+			foundSelection = true
+		}
+	}
+	if currentObjDetail != "Sales.Order" {
+		t.Errorf("expected $currentObject detail = %q, got %q", "Sales.Order", currentObjDetail)
+	}
+	if !foundSelection {
+		t.Error("expected $dgOrders selection variable in completion items")
+	}
+}
+
+func TestScanEnclosingDataContainer(t *testing.T) {
+	tests := []struct {
+		name           string
+		text           string
+		cursorLine     int
+		wantEntity     string
+		wantWidgetName string
+	}{
+		{
+			name:           "inside DATAVIEW",
+			text:           "DATAVIEW dv1 (DataSource: DATABASE FROM Mod.Order) {\n  TEXTBOX t1\n}",
+			cursorLine:     1,
+			wantEntity:     "Mod.Order",
+			wantWidgetName: "",
+		},
+		{
+			name:           "inside DATAGRID",
+			text:           "DATAGRID dg1 (DataSource: DATABASE FROM Shop.Product) {\n  COLUMN Name {\n    TEXTBOX t1\n  }\n}",
+			cursorLine:     2,
+			wantEntity:     "Shop.Product",
+			wantWidgetName: "dg1",
+		},
+		{
+			name:           "no container",
+			text:           "CREATE PAGE Mod.Page ($P: Mod.E) {\n  TEXTBOX t1\n}",
+			cursorLine:     1,
+			wantEntity:     "",
+			wantWidgetName: "",
+		},
+		{
+			name:           "nested DataView inside DataGrid",
+			text:           "DATAGRID dg1 (DataSource: DATABASE FROM Sales.Order) {\n  COLUMN col1 {\n    DATAVIEW dv1 (DataSource: DATABASE FROM Sales.Line) {\n      TEXTBOX t1\n    }\n  }\n}",
+			cursorLine:     3,
+			wantEntity:     "Sales.Line",
+			wantWidgetName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entity, widgetName := scanEnclosingDataContainer(tt.text, tt.cursorLine)
+			if entity != tt.wantEntity {
+				t.Errorf("scanEnclosingDataContainer() entity = %q, want %q", entity, tt.wantEntity)
+			}
+			if widgetName != tt.wantWidgetName {
+				t.Errorf("scanEnclosingDataContainer() widgetName = %q, want %q", widgetName, tt.wantWidgetName)
+			}
+		})
 	}
 }

--- a/mdl/executor/cmd_pages_describe_parse.go
+++ b/mdl/executor/cmd_pages_describe_parse.go
@@ -23,7 +23,11 @@ func extractConditionalSettings(widget *rawWidget, w map[string]any) {
 	}
 }
 
-func (e *Executor) parseRawWidget(w map[string]any) []rawWidget {
+func (e *Executor) parseRawWidget(w map[string]any, parentEntityContext ...string) []rawWidget {
+	inheritedCtx := ""
+	if len(parentEntityContext) > 0 {
+		inheritedCtx = parentEntityContext[0]
+	}
 	typeName, _ := w["$Type"].(string)
 	name, _ := w["Name"].(string)
 
@@ -65,7 +69,7 @@ func (e *Executor) parseRawWidget(w map[string]any) []rawWidget {
 		if children != nil {
 			for _, c := range children {
 				if cMap, ok := c.(map[string]any); ok {
-					widget.Children = append(widget.Children, e.parseRawWidget(cMap)...)
+					widget.Children = append(widget.Children, e.parseRawWidget(cMap, inheritedCtx)...)
 				}
 			}
 		}
@@ -91,7 +95,7 @@ func (e *Executor) parseRawWidget(w map[string]any) []rawWidget {
 
 	switch typeName {
 	case "Forms$LayoutGrid", "Pages$LayoutGrid":
-		widget.Rows = e.parseLayoutGridRows(w)
+		widget.Rows = e.parseLayoutGridRows(w, inheritedCtx)
 		return []rawWidget{widget}
 
 	case "Forms$DynamicText", "Pages$DynamicText":
@@ -121,11 +125,13 @@ func (e *Executor) parseRawWidget(w map[string]any) []rawWidget {
 		return []rawWidget{widget}
 
 	case "Forms$DataView", "Pages$DataView":
-		widget.Children = e.parseDataViewChildren(w)
 		widget.DataSource = e.extractDataViewDataSource(w)
 		if widget.DataSource != nil && widget.DataSource.Reference != "" {
 			widget.EntityContext = widget.DataSource.Reference
+		} else if inheritedCtx != "" {
+			widget.EntityContext = inheritedCtx
 		}
+		widget.Children = e.parseDataViewChildren(w, widget.EntityContext)
 		return []rawWidget{widget}
 
 	case "Forms$TextBox", "Pages$TextBox":
@@ -175,8 +181,6 @@ func (e *Executor) parseRawWidget(w map[string]any) []rawWidget {
 		// For DataGrid2, also extract datasource, columns, CONTROLBAR widgets, paging, and selection
 		if widget.RenderMode == "DATAGRID2" {
 			widget.DataSource = e.extractDataGrid2DataSource(w)
-			widget.DataGridColumns = e.extractDataGrid2Columns(w)
-			widget.ControlBar = e.extractDataGrid2ControlBar(w)
 			widget.PageSize = e.extractCustomWidgetPropertyString(w, "pageSize")
 			widget.Pagination = e.extractCustomWidgetPropertyString(w, "pagination")
 			widget.PagingPosition = e.extractCustomWidgetPropertyString(w, "pagingPosition")
@@ -185,20 +189,26 @@ func (e *Executor) parseRawWidget(w map[string]any) []rawWidget {
 			widget.Selection = e.extractGallerySelection(w)
 			if widget.DataSource != nil && widget.DataSource.Reference != "" {
 				widget.EntityContext = widget.DataSource.Reference
+			} else if inheritedCtx != "" {
+				widget.EntityContext = inheritedCtx
 			}
+			widget.DataGridColumns = e.extractDataGrid2Columns(w, widget.EntityContext)
+			widget.ControlBar = e.extractDataGrid2ControlBar(w)
 		}
 		// For Gallery, extract datasource, content widgets, filter widgets, and selection mode
 		if widget.RenderMode == "GALLERY" {
 			widget.DataSource = e.extractGalleryDataSource(w)
-			widget.Children = e.extractGalleryContent(w)
-			widget.FilterWidgets = e.extractGalleryFilters(w)
 			widget.Selection = e.extractGallerySelection(w)
 			widget.DesktopColumns = e.extractCustomWidgetPropertyString(w, "desktopItems")
 			widget.TabletColumns = e.extractCustomWidgetPropertyString(w, "tabletItems")
 			widget.PhoneColumns = e.extractCustomWidgetPropertyString(w, "phoneItems")
 			if widget.DataSource != nil && widget.DataSource.Reference != "" {
 				widget.EntityContext = widget.DataSource.Reference
+			} else if inheritedCtx != "" {
+				widget.EntityContext = inheritedCtx
 			}
+			widget.Children = e.extractGalleryContent(w, widget.EntityContext)
+			widget.FilterWidgets = e.extractGalleryFilters(w)
 		}
 		// For filter widgets, extract filter attributes and expression
 		if widget.RenderMode == "TEXTFILTER" || widget.RenderMode == "NUMBERFILTER" || widget.RenderMode == "DROPDOWNFILTER" || widget.RenderMode == "DATEFILTER" {
@@ -225,11 +235,13 @@ func (e *Executor) parseRawWidget(w map[string]any) []rawWidget {
 		return []rawWidget{widget}
 
 	case "Forms$Gallery", "Pages$Gallery":
-		widget.Children = e.parseGalleryContent(w)
 		widget.DataSource = e.extractGalleryDataSource(w)
 		if widget.DataSource != nil && widget.DataSource.Reference != "" {
 			widget.EntityContext = widget.DataSource.Reference
+		} else if inheritedCtx != "" {
+			widget.EntityContext = inheritedCtx
 		}
+		widget.Children = e.parseGalleryContent(w, widget.EntityContext)
 		return []rawWidget{widget}
 
 	case "Forms$SnippetCallWidget", "Pages$SnippetCallWidget":
@@ -237,11 +249,13 @@ func (e *Executor) parseRawWidget(w map[string]any) []rawWidget {
 		return []rawWidget{widget}
 
 	case "Forms$ListView", "Pages$ListView":
-		widget.Children = e.parseListViewContent(w)
 		widget.DataSource = e.extractListViewDataSource(w)
 		if widget.DataSource != nil && widget.DataSource.Reference != "" {
 			widget.EntityContext = widget.DataSource.Reference
+		} else if inheritedCtx != "" {
+			widget.EntityContext = inheritedCtx
 		}
+		widget.Children = e.parseListViewContent(w, widget.EntityContext)
 		return []rawWidget{widget}
 
 	default:
@@ -250,7 +264,11 @@ func (e *Executor) parseRawWidget(w map[string]any) []rawWidget {
 	}
 }
 
-func (e *Executor) parseLayoutGridRows(w map[string]any) []rawWidgetRow {
+func (e *Executor) parseLayoutGridRows(w map[string]any, entityContext ...string) []rawWidgetRow {
+	ctx := ""
+	if len(entityContext) > 0 {
+		ctx = entityContext[0]
+	}
 	rows := getBsonArrayElements(w["Rows"])
 	if rows == nil {
 		return nil
@@ -286,7 +304,7 @@ func (e *Executor) parseLayoutGridRows(w map[string]any) []rawWidgetRow {
 			colWidgets := getBsonArrayElements(cMap["Widgets"])
 			for _, cw := range colWidgets {
 				if cwMap, ok := cw.(map[string]any); ok {
-					col.Widgets = append(col.Widgets, e.parseRawWidget(cwMap)...)
+					col.Widgets = append(col.Widgets, e.parseRawWidget(cwMap, ctx)...)
 				}
 			}
 			row.Columns = append(row.Columns, col)
@@ -381,14 +399,19 @@ func (e *Executor) extractNavigationListItemAction(w map[string]any) string {
 }
 
 // parseDataViewChildren extracts child widgets from a DataView.
-func (e *Executor) parseDataViewChildren(w map[string]any) []rawWidget {
+// entityContext is the resolved entity context from the enclosing data container.
+func (e *Executor) parseDataViewChildren(w map[string]any, entityContext ...string) []rawWidget {
+	ctx := ""
+	if len(entityContext) > 0 {
+		ctx = entityContext[0]
+	}
 	var result []rawWidget
 
 	// Get main widgets
 	widgets := getBsonArrayElements(w["Widgets"])
 	for _, child := range widgets {
 		if childMap, ok := child.(map[string]any); ok {
-			result = append(result, e.parseRawWidget(childMap)...)
+			result = append(result, e.parseRawWidget(childMap, ctx)...)
 		}
 	}
 
@@ -399,7 +422,7 @@ func (e *Executor) parseDataViewChildren(w map[string]any) []rawWidget {
 		footer := rawWidget{Type: "Footer", Name: "footer1"}
 		for _, child := range footerWidgets {
 			if childMap, ok := child.(map[string]any); ok {
-				footer.Children = append(footer.Children, e.parseRawWidget(childMap)...)
+				footer.Children = append(footer.Children, e.parseRawWidget(childMap, ctx)...)
 			}
 		}
 		result = append(result, footer)
@@ -542,7 +565,12 @@ func (e *Executor) extractAttributeRef(w map[string]any) string {
 }
 
 // parseGalleryContent extracts the content widget from a Gallery.
-func (e *Executor) parseGalleryContent(w map[string]any) []rawWidget {
+// entityContext is the resolved entity context from the Gallery's datasource.
+func (e *Executor) parseGalleryContent(w map[string]any, entityContext ...string) []rawWidget {
+	ctx := ""
+	if len(entityContext) > 0 {
+		ctx = entityContext[0]
+	}
 	content := w["ContentWidget"]
 	if content == nil {
 		return nil
@@ -551,11 +579,16 @@ func (e *Executor) parseGalleryContent(w map[string]any) []rawWidget {
 	if !ok {
 		return nil
 	}
-	return e.parseRawWidget(contentMap)
+	return e.parseRawWidget(contentMap, ctx)
 }
 
 // parseListViewContent extracts the content widgets from a ListView.
-func (e *Executor) parseListViewContent(w map[string]any) []rawWidget {
+// entityContext is the resolved entity context from the enclosing list container.
+func (e *Executor) parseListViewContent(w map[string]any, entityContext ...string) []rawWidget {
+	ctx := ""
+	if len(entityContext) > 0 {
+		ctx = entityContext[0]
+	}
 	widgets := getBsonArrayElements(w["Widgets"])
 	if widgets == nil {
 		return nil
@@ -566,7 +599,7 @@ func (e *Executor) parseListViewContent(w map[string]any) []rawWidget {
 		if !ok {
 			continue
 		}
-		result = append(result, e.parseRawWidget(wgtMap)...)
+		result = append(result, e.parseRawWidget(wgtMap, ctx)...)
 	}
 	return result
 }

--- a/mdl/executor/cmd_pages_describe_pluggable.go
+++ b/mdl/executor/cmd_pages_describe_pluggable.go
@@ -221,7 +221,8 @@ func (e *Executor) extractDataGrid2DataSource(w map[string]any) *rawDataSource {
 }
 
 // extractDataGrid2Columns extracts the columns from a DataGrid2 CustomWidget.
-func (e *Executor) extractDataGrid2Columns(w map[string]any) []rawDataGridColumn {
+// entityContext is the resolved entity context from the DataGrid2's datasource.
+func (e *Executor) extractDataGrid2Columns(w map[string]any, entityContext ...string) []rawDataGridColumn {
 	obj, ok := w["Object"].(map[string]any)
 	if !ok {
 		return nil
@@ -247,13 +248,17 @@ func (e *Executor) extractDataGrid2Columns(w map[string]any) []rawDataGridColumn
 			continue
 		}
 
+		ctx := ""
+		if len(entityContext) > 0 {
+			ctx = entityContext[0]
+		}
 		var columns []rawDataGridColumn
 		for _, colObj := range objects {
 			colMap, ok := colObj.(map[string]any)
 			if !ok {
 				continue
 			}
-			col := e.extractDataGrid2Column(colMap, colPropKeyMap)
+			col := e.extractDataGrid2Column(colMap, colPropKeyMap, ctx)
 			if col.Attribute != "" || col.Caption != "" {
 				columns = append(columns, col)
 			}
@@ -326,7 +331,7 @@ func (e *Executor) buildColumnPropertyKeyMap(w map[string]any) map[string]string
 // - "dynamicText": TextTemplate for dynamic text (when showContentAs = "dynamicText")
 // - "alignment": enum value ("left", "center", "right")
 // - "wrapText": boolean ("true", "false")
-func (e *Executor) extractDataGrid2Column(colObj map[string]any, colPropKeyMap map[string]string) rawDataGridColumn {
+func (e *Executor) extractDataGrid2Column(colObj map[string]any, colPropKeyMap map[string]string, entityContext string) rawDataGridColumn {
 	col := rawDataGridColumn{}
 
 	// Track if we've found the header to avoid overwriting with dynamicText's TextTemplate
@@ -460,7 +465,7 @@ func (e *Executor) extractDataGrid2Column(colObj map[string]any, colPropKeyMap m
 			if len(widgets) > 0 {
 				for _, w := range widgets {
 					if wMap, ok := w.(map[string]any); ok {
-						col.ContentWidgets = append(col.ContentWidgets, e.parseRawWidget(wMap)...)
+						col.ContentWidgets = append(col.ContentWidgets, e.parseRawWidget(wMap, entityContext)...)
 					}
 				}
 			}
@@ -690,12 +695,22 @@ func (e *Executor) parseCustomWidgetDataSource(ds map[string]any) *rawDataSource
 }
 
 // extractGalleryContent extracts the content widgets from a CustomWidget Gallery.
-func (e *Executor) extractGalleryContent(w map[string]any) []rawWidget {
-	return e.extractGalleryWidgetsByPropertyKey(w, "content")
+// entityContext is the resolved entity context from the Gallery's datasource.
+func (e *Executor) extractGalleryContent(w map[string]any, entityContext ...string) []rawWidget {
+	ctx := ""
+	if len(entityContext) > 0 {
+		ctx = entityContext[0]
+	}
+	return e.extractGalleryWidgetsByPropertyKey(w, "content", ctx)
 }
 
 // extractGalleryWidgetsByPropertyKey extracts widgets from a named property of a CustomWidget Gallery.
-func (e *Executor) extractGalleryWidgetsByPropertyKey(w map[string]any, targetKey string) []rawWidget {
+// entityContext is the resolved entity context to propagate to child widgets.
+func (e *Executor) extractGalleryWidgetsByPropertyKey(w map[string]any, targetKey string, entityContext ...string) []rawWidget {
+	ctx := ""
+	if len(entityContext) > 0 {
+		ctx = entityContext[0]
+	}
 	obj, ok := w["Object"].(map[string]any)
 	if !ok {
 		return nil
@@ -739,7 +754,7 @@ func (e *Executor) extractGalleryWidgetsByPropertyKey(w map[string]any, targetKe
 			if !ok {
 				continue
 			}
-			result = append(result, e.parseRawWidget(wgtMap)...)
+			result = append(result, e.parseRawWidget(wgtMap, ctx)...)
 		}
 		return result
 	}
@@ -767,7 +782,7 @@ func (e *Executor) extractGalleryWidgetsByPropertyKey(w map[string]any, targetKe
 				if !ok {
 					continue
 				}
-				result = append(result, e.parseRawWidget(wgtMap)...)
+				result = append(result, e.parseRawWidget(wgtMap, ctx)...)
 			}
 			if len(result) > 0 {
 				return result

--- a/mdl/executor/data_container_context_test.go
+++ b/mdl/executor/data_container_context_test.go
@@ -86,3 +86,46 @@ func TestOutputWidgetMDLV3_ListViewWithContext(t *testing.T) {
 		t.Errorf("ListView output should contain context comment with selection, got:\n%s", got)
 	}
 }
+
+func TestOutputWidgetMDLV3_DataViewInheritsParentContext(t *testing.T) {
+	// A DataView without its own DataSource should inherit parent context
+	buf := &bytes.Buffer{}
+	e := New(buf)
+	w := rawWidget{
+		Type:          "Forms$DataView",
+		Name:          "dvNested",
+		EntityContext: "Sales.OrderLine", // inherited from parent during parse
+		Children: []rawWidget{
+			{Type: "Forms$TextBox", Name: "txtQty", Content: "Quantity"},
+		},
+	}
+	e.outputWidgetMDLV3(w, 0)
+	got := buf.String()
+	if !strings.Contains(got, "-- Context: $currentObject (Sales.OrderLine)") {
+		t.Errorf("Nested DataView should show inherited context, got:\n%s", got)
+	}
+}
+
+func TestOutputWidgetMDLV3_DataGridColumnInheritsContext(t *testing.T) {
+	// DataGrid2 column content widgets should inherit DataGrid2's context
+	buf := &bytes.Buffer{}
+	e := New(buf)
+	w := rawWidget{
+		Type:          "CustomWidgets$CustomWidget",
+		Name:          "dgProducts",
+		RenderMode:    "DATAGRID2",
+		EntityContext: "Shop.Product",
+		DataSource:    &rawDataSource{Type: "database", Reference: "Shop.Product"},
+		DataGridColumns: []rawDataGridColumn{
+			{
+				Attribute: "Name",
+				Caption:   "Product Name",
+			},
+		},
+	}
+	e.outputWidgetMDLV3(w, 0)
+	got := buf.String()
+	if !strings.Contains(got, "-- Context: $currentObject (Shop.Product), $dgProducts (selection)") {
+		t.Errorf("DataGrid2 should show context comment, got:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix `extractPageParamNames` to use `$Name: Type` declaration pattern matching instead of full-document `$Name` scanning, eliminating false positives from `$currentObject`, body `$var` references, and comment lines
- Propagate `EntityContext` through nested widget tree so data containers without own DataSource inherit parent context (fixes missing context comments for nested DataView via association)
- Add upward scope scanning in LSP `$` completion to show `$currentObject` with actual entity type and `$widgetName` selection variables for list containers

Addresses review comments from #168.

## Test plan
- [x] `extractPageParamNames` — 7 test cases including false positive rejection
- [x] `scanEnclosingDataContainer` — 4 test cases (DATAVIEW, DATAGRID, no container, nested)
- [x] `variableCompletionItems` — 2 test cases (basic, DataGrid with entity type + selection)
- [x] `outputWidgetMDLV3` — 2 new inherited context tests (DataView, DataGrid column)
- [x] `make build` and `make test` pass