### PR TITLE
fix: skip Attribute fallback for custom-content datagrid columns

### DIFF
--- a/mdl/executor/cmd_pages_builder_v3_widgets.go
+++ b/mdl/executor/cmd_pages_builder_v3_widgets.go
@@ -128,10 +128,9 @@ func (pb *pageBuilder) buildDataGridV3(w *ast.WidgetV3) (*pages.CustomWidget, er
 			attr := child.GetAttribute()
 			// Sugar: when no explicit Attribute: property is given, fall back to
 			// the column's name. This lets `COLUMN Sku (Caption: 'SKU')` work
-			// without repeating `Attribute: Sku`. If the name starts with a
-			// lowercase prefix like "col" (convention for decoration), it won't
-			// resolve to a real attribute — and mx check will flag it later.
-			if attr == "" && child.Name != "" {
+			// without repeating `Attribute: Sku`. Skip for custom-content columns
+			// (those with a body of child widgets), which don't bind to an attribute.
+			if attr == "" && child.Name != "" && len(child.Children) == 0 {
 				attr = child.Name
 			}
 			col := ast.DataGridColumnDef{


### PR DESCRIPTION
## Summary

PR #202 added a sugar that falls back to the column's name when no explicit `Attribute:` is given. That's nice for `COLUMN Sku (Caption: 'SKU')`, but for custom-content columns (those with an action-button body and no attribute binding), it caused:

```
[error] [CE1613] "The selected attribute 'PgTest.Product.colActions' no longer exists."
```

Because names like `colActions` don't resolve to real attributes.

## Fix

Skip the sugar when the column has child widgets — those columns don't bind to an attribute.

```go
if attr == "" && child.Name != "" && len(child.Children) == 0 {
    attr = child.Name
}
```

## Test plan

- [x] `go build ./...`
- [x] `go test ./mdl/executor/` (unit tests pass)
- [ ] CI integration test: `03-page-examples.mdl` should pass (the remaining main build failure)

Cases covered:
- `COLUMN Sku (Caption: 'SKU')` — no attr, no children → falls back to "Sku" ✓ (unchanged)
- `COLUMN colActions (Caption: 'Actions') { ACTIONBUTTON ... }` — no attr, has children → stays empty ✓ (fixed)
- `COLUMN colActions (Attribute: Name, ..., ShowContentAs: customContent) { ... }` — explicit attr → unchanged ✓