### PR TITLE
Update parsing of ScrollContainer and TabControl

### DIFF
--- a/mdl/executor/cmd_pages_describe_output.go
+++ b/mdl/executor/cmd_pages_describe_output.go
@@ -128,6 +128,32 @@ func (e *Executor) outputWidgetMDLV3(w rawWidget, indent int) {
 	prefix := strings.Repeat("  ", indent)
 
 	switch w.Type {
+	case "Forms$TabControl", "Pages$TabControl":
+		header := fmt.Sprintf("TABCONTAINER %s", w.Name)
+		props := appendAppearanceProps(nil, w)
+		if len(w.Children) > 0 {
+			formatWidgetProps(e.output, prefix, header, props, " {\n")
+			for _, child := range w.Children {
+				e.outputWidgetMDLV3(child, indent+1)
+			}
+			fmt.Fprintf(e.output, "%s}\n", prefix)
+		} else {
+			formatWidgetProps(e.output, prefix, header, props, "\n")
+		}
+
+	case "Forms$ScrollContainer", "Pages$ScrollContainer":
+		header := fmt.Sprintf("SCROLLCONTAINER %s", w.Name)
+		props := appendAppearanceProps(nil, w)
+		if len(w.Children) > 0 {
+			formatWidgetProps(e.output, prefix, header, props, " {\n")
+			for _, child := range w.Children {
+				e.outputWidgetMDLV3(child, indent+1)
+			}
+			fmt.Fprintf(e.output, "%s}\n", prefix)
+		} else {
+			formatWidgetProps(e.output, prefix, header, props, "\n")
+		}
+
 	case "Forms$DivContainer", "Pages$DivContainer":
 		header := fmt.Sprintf("CONTAINER %s", w.Name)
 		props := appendAppearanceProps(nil, w)

--- a/mdl/executor/cmd_pages_describe_parse.go
+++ b/mdl/executor/cmd_pages_describe_parse.go
@@ -31,6 +31,54 @@ func (e *Executor) parseRawWidget(w map[string]any, parentEntityContext ...strin
 	typeName, _ := w["$Type"].(string)
 	name, _ := w["Name"].(string)
 
+	// ScrollContainer: children live in CenterRegion.Widgets (not Widgets directly).
+	// We keep the scrollContainer widget ID in the output but also expose all nested
+	// widgets so DESCRIBE PAGE shows what's inside and the extractor can find them.
+	if typeName == "Forms$ScrollContainer" || typeName == "Pages$ScrollContainer" {
+		widget := rawWidget{
+			Type: typeName,
+			Name: name,
+		}
+		// Children are nested inside CenterRegion.Widgets
+		var children []any
+		if centerRegion, ok := w["CenterRegion"].(map[string]any); ok {
+			children = getBsonArrayElements(centerRegion["Widgets"])
+		}
+		// Fallback: some older formats may use Widgets directly
+		if children == nil {
+			children = getBsonArrayElements(w["Widgets"])
+		}
+		for _, c := range children {
+			if cMap, ok := c.(map[string]any); ok {
+				widget.Children = append(widget.Children, e.parseRawWidget(cMap, inheritedCtx)...)
+			}
+		}
+		return []rawWidget{widget}
+	}
+
+	// TabControl: children live in TabPages[].Widgets — recurse so nested widget IDs
+	// (e.g. text widgets inside each tab) are included in the output.
+	if typeName == "Forms$TabControl" || typeName == "Pages$TabControl" {
+		widget := rawWidget{
+			Type: typeName,
+			Name: name,
+		}
+		tabPages := getBsonArrayElements(w["TabPages"])
+		for _, tp := range tabPages {
+			tpMap, ok := tp.(map[string]any)
+			if !ok {
+				continue
+			}
+			tabWidgets := getBsonArrayElements(tpMap["Widgets"])
+			for _, tw := range tabWidgets {
+				if twMap, ok := tw.(map[string]any); ok {
+					widget.Children = append(widget.Children, e.parseRawWidget(twMap, inheritedCtx)...)
+				}
+			}
+		}
+		return []rawWidget{widget}
+	}
+
 	// Parse DivContainer as a proper CONTAINER widget with children
 	if typeName == "Forms$DivContainer" || typeName == "Pages$DivContainer" ||
 		typeName == "Forms$GroupBox" || typeName == "Pages$GroupBox" {


### PR DESCRIPTION
**The problem:**

When mxcli runs DESCRIBE PAGE, it walks the widget tree in the .mpr BSON and outputs every widget with its ID. The Python extractor (extract_mendix_artifacts.py) then parses that output to build the artifact map. But two container widget types were not traversing their children:

ScrollContainer — Mendix stores its children in CenterRegion.Widgets, not in Widgets directly (like most other containers). So mxcli saw the ScrollContainer itself but never recursed into it — every widget nested inside a ScrollContainer was invisible.

TabControl — Mendix stores children in TabPages[].Widgets (an array of tab pages, each with its own Widgets array). Same problem — mxcli saw the TabControl but not the widgets on each tab.

**The impact on test impact analysis:**

Without this fix, the extractor was missing 115 widget IDs (509 → 624 after the fix). Those missing IDs meant the linkage map couldn't connect certain test tags to their Mendix project artifacts. Any test that asserted on a widget inside a ScrollContainer or TabControl had a broken linkage — the system wouldn't know which page (and therefore which appdev code) that test exercises.

In short: mxcli couldn't see inside these two container types → extractor missed widgets → linkage map had gaps → test impact analysis would have blind spots for those areas.