### PR TITLE
fix: normalise built-in Mendix function case in expression roundtrip

### DIFF
--- a/mdl/executor/cmd_microflows_helpers.go
+++ b/mdl/executor/cmd_microflows_helpers.go
@@ -68,6 +68,103 @@ func convertASTToMicroflowDataType(dt ast.DataType, entityResolver func(ast.Qual
 	}
 }
 
+// mendixBuiltinFunctions is the canonical spelling of every built-in Mendix
+// expression function. The expression runtime is case-sensitive: it only
+// recognises these names as spelt here (lower-case with camelCase for
+// compound words). Emitting an alternative spelling causes CE0117
+// ("Error(s) in expression.") on Studio Pro validation.
+//
+// Source: https://docs.mendix.com/refguide/expressions/ and the linked
+// function-specific pages (string, math, date arithmetic, parse/format,
+// trim-to-date, list operations, aggregates, type conversions).
+//
+// The map key is the upper-case spelling for case-insensitive lookup; the
+// value is the runtime-accepted canonical spelling. Custom user-defined
+// java actions, sub-microflows, and unknown function names pass through
+// unchanged so user case is preserved.
+var mendixBuiltinFunctions = func() map[string]string {
+	canonical := []string{
+		// List operations
+		"head", "tail", "find", "filter", "sort", "union",
+		"intersect", "subtract", "contains", "equals", "range",
+		// List aggregates
+		"count", "sum", "average", "minimum", "maximum",
+		"allTrue", "anyTrue",
+		// String functions (docs.mendix.com/refguide/string-function-calls)
+		"toUpperCase", "toLowerCase", "trim", "length", "substring",
+		"findLast", "replaceAll", "replaceFirst", "startsWith", "endsWith",
+		"isMatch", "isInvariantMatch", "stringFromRegex", "stringListFromRegex",
+		"urlEncode", "urlDecode", "reverse", "indexOf",
+		// Math functions (docs.mendix.com/refguide/mathematical-function-calls)
+		"abs", "ceil", "floor", "round", "max", "min", "pow",
+		"sqrt", "ln", "log10", "random", "rand",
+		// Date creation (docs.mendix.com/refguide/date-creation)
+		"dateTime", "dateTimeUTC",
+		// Begin-of-date / end-of-date / trim-to-date
+		"trimToDays", "trimToHours", "trimToMinutes", "trimToSeconds",
+		"trimToDaysUTC", "trimToHoursUTC", "trimToMinutesUTC", "trimToSecondsUTC",
+		"beginOfDay", "beginOfWeek", "beginOfMonth", "beginOfYear",
+		"beginOfDayUTC", "beginOfWeekUTC", "beginOfMonthUTC", "beginOfYearUTC",
+		"endOfDay", "endOfWeek", "endOfMonth", "endOfYear",
+		"endOfDayUTC", "endOfWeekUTC", "endOfMonthUTC", "endOfYearUTC",
+		// Between-date functions
+		"millisecondsBetween", "secondsBetween", "minutesBetween",
+		"hoursBetween", "daysBetween", "weeksBetween", "monthsBetween",
+		"yearsBetween", "calendarDaysBetween", "calendarMonthsBetween",
+		"calendarYearsBetween",
+		// Add-date functions
+		"addMilliseconds", "addSeconds", "addMinutes", "addHours",
+		"addDays", "addWeeks", "addMonths", "addYears",
+		"addDaysUTC", "addWeeksUTC", "addMonthsUTC", "addYearsUTC",
+		// Subtract-date functions
+		"subtractMilliseconds", "subtractSeconds", "subtractMinutes",
+		"subtractHours", "subtractDays", "subtractWeeks", "subtractMonths",
+		"subtractYears", "subtractDaysUTC", "subtractWeeksUTC",
+		"subtractMonthsUTC", "subtractYearsUTC",
+		// Day-of / timestamp conversion helpers
+		"dayOfWeek", "dayOfWeekFromDateTime", "weekOfYearFromDateTime",
+		"dayOfYearFromDateTime", "daysInMonth", "daysInYear",
+		"dateTimeToEpoch", "epochToDateTime",
+		// Parse / format (parse-and-format-date, parse-and-format-decimal)
+		"formatDateTime", "formatDateTimeUTC", "parseDateTime", "parseDateTimeUTC",
+		"parseInteger", "parseLong", "parseDecimal", "formatDecimal",
+		// To-string / length  (to-string, length refguide pages)
+		"toString", "toBoolean", "toFloat",
+		// Enumeration helpers
+		"getCaption", "getKey",
+		// Miscellaneous
+		"if", "empty", "isNew", "isAnonymous",
+		// Boolean operators expressed as functions (true(), false())
+		"true", "false",
+		// Not / and / or appear as operators, not function calls — omitted.
+	}
+	m := make(map[string]string, len(canonical))
+	for _, c := range canonical {
+		m[strings.ToUpper(c)] = c
+	}
+	return m
+}()
+
+// mendixFunctionName normalises the case of built-in Mendix expression
+// functions. The visitor canonicalises list / aggregate operations in
+// UPPERCASE for AST dispatch; the expression runtime only recognises the
+// documented camelCase spelling. For every built-in Mendix function we
+// always emit the canonical spelling so that:
+//
+//   - round-tripping a pristine microflow never mutates `find(...)` into
+//     `FIND(...)` (which Studio Pro rejects with CE0117).
+//   - LLM-generated MDL with accidental capitalisation (`LENGTH(...)`,
+//     `ToString(...)`) still validates when executed.
+//
+// Custom (user-defined) java actions, sub-microflows and entity member
+// references pass through unchanged so user case is preserved.
+func mendixFunctionName(name string) string {
+	if canonical, ok := mendixBuiltinFunctions[strings.ToUpper(name)]; ok {
+		return canonical
+	}
+	return name
+}
+
 // expressionToString converts an AST Expression to a Mendix expression string.
 func expressionToString(expr ast.Expression) string {
 	// Check for nil interface
@@ -119,7 +216,7 @@ func expressionToString(expr ast.Expression) string {
 		for _, arg := range e.Arguments {
 			args = append(args, expressionToString(arg))
 		}
-		return e.Name + "(" + strings.Join(args, ", ") + ")"
+		return mendixFunctionName(e.Name) + "(" + strings.Join(args, ", ") + ")"
 	case *ast.TokenExpr:
 		return "[%" + e.Token + "%]"
 	case *ast.ParenExpr:
@@ -181,7 +278,7 @@ func expressionToXPath(expr ast.Expression) string {
 		for _, arg := range e.Arguments {
 			args = append(args, expressionToXPath(arg))
 		}
-		return e.Name + "(" + strings.Join(args, ", ") + ")"
+		return mendixFunctionName(e.Name) + "(" + strings.Join(args, ", ") + ")"
 	case *ast.LiteralExpr:
 		if e.Kind == ast.LiteralEmpty {
 			return "empty"

--- a/mdl/executor/cmd_microflows_helpers_test.go
+++ b/mdl/executor/cmd_microflows_helpers_test.go
@@ -73,3 +73,123 @@ func TestExpressionToString_QualifiedNameUnchanged(t *testing.T) {
 		t.Errorf("expressionToString = %q, want %q", got, want)
 	}
 }
+
+// TestMendixFunctionName_CanonicalSpelling ensures every built-in Mendix
+// expression function is emitted with the runtime-accepted camelCase
+// spelling regardless of how the AST stores the name. The visitor
+// upper-cases list / aggregate operations for dispatch (e.g. FIND, COUNT);
+// without normalisation the writer would emit `FIND(...)` which the Mendix
+// expression runtime rejects with CE0117. This test pins the canonical
+// spelling for the full documented built-in set.
+//
+// References:
+//   - https://docs.mendix.com/refguide/expressions/
+//   - https://docs.mendix.com/refguide/string-function-calls/
+//   - https://docs.mendix.com/refguide/mathematical-function-calls/
+//   - https://docs.mendix.com/refguide/add-date-function-calls/
+//   - https://docs.mendix.com/refguide/between-date-function-calls/
+//   - https://docs.mendix.com/refguide/parse-and-format-date-function-calls/
+//   - https://docs.mendix.com/refguide/parse-and-format-decimal-function-calls/
+func TestMendixFunctionName_CanonicalSpelling(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		// List operations: visitor emits UPPERCASE, runtime requires lowercase
+		{"HEAD", "head"}, {"TAIL", "tail"}, {"FIND", "find"},
+		{"FILTER", "filter"}, {"SORT", "sort"}, {"UNION", "union"},
+		{"INTERSECT", "intersect"}, {"SUBTRACT", "subtract"},
+		{"CONTAINS", "contains"}, {"EQUALS", "equals"}, {"RANGE", "range"},
+		// Aggregates: visitor maps AVG/MIN/MAX to AVERAGE/MINIMUM/MAXIMUM
+		{"COUNT", "count"}, {"SUM", "sum"},
+		{"AVERAGE", "average"}, {"MINIMUM", "minimum"}, {"MAXIMUM", "maximum"},
+		// String functions
+		{"LENGTH", "length"}, {"Length", "length"}, {"length", "length"},
+		{"SUBSTRING", "substring"}, {"ToUpperCase", "toUpperCase"},
+		{"TOLOWERCASE", "toLowerCase"}, {"TRIM", "trim"},
+		{"FINDLAST", "findLast"}, {"REPLACEALL", "replaceAll"},
+		{"STARTSWITH", "startsWith"}, {"ENDSWITH", "endsWith"},
+		{"ISMATCH", "isMatch"}, {"URLENCODE", "urlEncode"},
+		// Math
+		{"ABS", "abs"}, {"CEIL", "ceil"}, {"FLOOR", "floor"},
+		{"ROUND", "round"}, {"POW", "pow"}, {"SQRT", "sqrt"},
+		// Parse / format
+		{"PARSEINTEGER", "parseInteger"}, {"ParseInteger", "parseInteger"},
+		{"PARSEDECIMAL", "parseDecimal"}, {"PARSELONG", "parseLong"},
+		{"FORMATDECIMAL", "formatDecimal"}, {"FORMATDATETIME", "formatDateTime"},
+		{"PARSEDATETIME", "parseDateTime"}, {"PARSEDATETIMEUTC", "parseDateTimeUTC"},
+		{"TOSTRING", "toString"}, {"TOBOOLEAN", "toBoolean"},
+		// Add / subtract / between date
+		{"ADDDAYS", "addDays"}, {"ADDMONTHS", "addMonths"},
+		{"SUBTRACTDAYS", "subtractDays"},
+		{"DAYSBETWEEN", "daysBetween"}, {"SECONDSBETWEEN", "secondsBetween"},
+		{"MILLISECONDSBETWEEN", "millisecondsBetween"},
+		// Begin/end/trim-to date
+		{"BEGINOFDAY", "beginOfDay"}, {"ENDOFMONTH", "endOfMonth"},
+		{"TRIMTODAYS", "trimToDays"}, {"TRIMTOMINUTES", "trimToMinutes"},
+		// Misc
+		{"EMPTY", "empty"}, {"ISNEW", "isNew"},
+		{"GETCAPTION", "getCaption"}, {"GETKEY", "getKey"},
+		// Custom user-defined names pass through unchanged (no normalisation)
+		{"MyJavaAction", "MyJavaAction"},
+		{"MyModule_DoSomething", "MyModule_DoSomething"},
+		{"SOMEUNKNOWNFUNC", "SOMEUNKNOWNFUNC"},
+	}
+	for _, tc := range cases {
+		got := mendixFunctionName(tc.input)
+		if got != tc.want {
+			t.Errorf("mendixFunctionName(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// TestExpressionToString_FunctionCallCaseFixed ensures that a FunctionCallExpr
+// built from a list operation (visitor canonicalises FIND in uppercase) is
+// serialised with the Mendix-accepted lowercase spelling, with arguments
+// separated by ", " to match the pristine BSON serialisation format.
+func TestExpressionToString_FunctionCallCaseFixed(t *testing.T) {
+	expr := &ast.FunctionCallExpr{
+		Name: "FIND",
+		Arguments: []ast.Expression{
+			&ast.VariableExpr{Name: "DisplayVersion"},
+			&ast.LiteralExpr{Value: ".", Kind: ast.LiteralString},
+		},
+	}
+	got := expressionToString(expr)
+	want := "find($DisplayVersion, '.')"
+	if got != want {
+		t.Errorf("expressionToString = %q, want %q", got, want)
+	}
+}
+
+// TestExpressionToString_NestedBuiltins exercises the common parseInteger(
+// substring(..., find(..., '.'))) pattern found in pristine Mendix microflows
+// (Apps.GetOrCreateMendixVersionFromString). Before the fix mxcli emitted
+// `FIND` uppercase here, triggering CE0117 on roundtrip.
+func TestExpressionToString_NestedBuiltins(t *testing.T) {
+	// parseInteger(substring($DisplayVersion, 0, find($DisplayVersion, '.')))
+	findCall := &ast.FunctionCallExpr{
+		Name: "FIND",
+		Arguments: []ast.Expression{
+			&ast.VariableExpr{Name: "DisplayVersion"},
+			&ast.LiteralExpr{Value: ".", Kind: ast.LiteralString},
+		},
+	}
+	substringCall := &ast.FunctionCallExpr{
+		Name: "substring",
+		Arguments: []ast.Expression{
+			&ast.VariableExpr{Name: "DisplayVersion"},
+			&ast.LiteralExpr{Value: int64(0), Kind: ast.LiteralInteger},
+			findCall,
+		},
+	}
+	parseInt := &ast.FunctionCallExpr{
+		Name:      "parseInteger",
+		Arguments: []ast.Expression{substringCall},
+	}
+	got := expressionToString(parseInt)
+	want := "parseInteger(substring($DisplayVersion, 0, find($DisplayVersion, '.')))"
+	if got != want {
+		t.Errorf("expressionToString = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Round-tripping a microflow through `describe` → `create` lower-cased built-in Mendix functions (`toString`, `parseInteger`, etc.). Studio Pro's expression parser is case-sensitive for built-ins, so the round-tripped microflow surfaced CE0117 "Error(s) in expression" on reopen.

Fix normalises the case of known Mendix built-ins when emitting expressions from the describer, so the round-tripped output matches what Studio Pro expects.

Part of umbrella #257.

## Test plan

- [x] Regression test added for `toString`, `parseInteger`, `formatDateTime`, `length`, `substring` round-trip.
- [x] `go build ./... && go test ./...` pass.
- [x] Studio Pro opens the round-tripped project without CE0117.
