### PR TITLE
fix: preserve decision/loop captions across nested control flow

### DIFF
--- a/mdl-examples/bug-tests/263-nested-caption-preservation.mdl
+++ b/mdl-examples/bug-tests/263-nested-caption-preservation.mdl
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- Bug #263: Preserve decision/loop captions across nested control flow
+-- ============================================================================
+--
+-- Symptom (before fix):
+--   `@caption` on an outer IF/LOOP/WHILE was being overwritten by the inner
+--   IF/LOOP's caption because `pendingAnnotations` was shared mutable state
+--   across recursive addStatement calls. Annotations attached to the outer
+--   split ended up bound to the inner split, and the outer split inherited
+--   whatever caption the inner statement carried.
+--
+-- After fix:
+--   addIfStatement / addLoopStatement / addWhileStatement snapshot + clear
+--   `pendingAnnotations` before recursing, then re-apply to their own activity
+--   after it's created. The WHILE case also gained explicit handling in
+--   mergeStatementAnnotations (previously fell through to `default: nil`).
+--
+-- Usage:
+--   mxcli exec mdl-examples/bug-tests/263-nested-caption-preservation.mdl -p app.mpr
+--   Open in Studio Pro — each split/loop displays its own caption, not
+--   inherited from a nested statement.
+-- ============================================================================
+
+create module BugTest263;
+
+create microflow BugTest263.MF_NestedCaptions (
+  $S: string
+)
+returns boolean as $ok
+begin
+  declare $ok boolean = false;
+
+  @caption 'String not empty?'
+  if $S != empty then
+    @caption 'Right format?'
+    if isMatch($S, 'x') then
+      return true;
+    else
+      return false;
+    end if;
+  else
+    return false;
+  end if;
+end;
+/

--- a/mdl/executor/cmd_microflows_builder_annotations.go
+++ b/mdl/executor/cmd_microflows_builder_annotations.go
@@ -37,6 +37,8 @@ func getStatementAnnotations(stmt ast.MicroflowStatement) *ast.ActivityAnnotatio
 		return s.Annotations
 	case *ast.LoopStmt:
 		return s.Annotations
+	case *ast.WhileStmt:
+		return s.Annotations
 	case *ast.LogStmt:
 		return s.Annotations
 	case *ast.CallMicroflowStmt:
@@ -135,6 +137,12 @@ func (fb *flowBuilder) applyAnnotations(activityID model.ID, ann *ast.ActivityAn
 					activity.Caption = ann.Caption
 				}
 			case *microflows.InheritanceSplit:
+				if ann.Caption != "" {
+					activity.Caption = ann.Caption
+				}
+			case *microflows.LoopedActivity:
+				// LOOP / WHILE activities can carry a caption just like
+				// splits and action activities.
 				if ann.Caption != "" {
 					activity.Caption = ann.Caption
 				}

--- a/mdl/executor/cmd_microflows_builder_annotations.go
+++ b/mdl/executor/cmd_microflows_builder_annotations.go
@@ -116,8 +116,8 @@ func (fb *flowBuilder) applyAnnotations(activityID model.ID, ann *ast.ActivityAn
 				continue
 			}
 
-			// @caption, @color, and @excluded — only applicable to ActionActivity
-			if activity, ok := obj.(*microflows.ActionActivity); ok {
+			switch activity := obj.(type) {
+			case *microflows.ActionActivity:
 				if ann.Caption != "" {
 					activity.Caption = ann.Caption
 					activity.AutoGenerateCaption = false
@@ -127,6 +127,16 @@ func (fb *flowBuilder) applyAnnotations(activityID model.ID, ann *ast.ActivityAn
 				}
 				if ann.Excluded {
 					activity.Disabled = true
+				}
+			case *microflows.ExclusiveSplit:
+				// Splits carry a human-readable Caption (e.g. "Right format?")
+				// independent of the expression/rule being evaluated.
+				if ann.Caption != "" {
+					activity.Caption = ann.Caption
+				}
+			case *microflows.InheritanceSplit:
+				if ann.Caption != "" {
+					activity.Caption = ann.Caption
 				}
 			}
 

--- a/mdl/executor/cmd_microflows_builder_annotations_test.go
+++ b/mdl/executor/cmd_microflows_builder_annotations_test.go
@@ -219,3 +219,94 @@ func TestIfAnnotationStaysWithCorrectSplit(t *testing.T) {
 		t.Errorf("inner note destination: got %q, want %q (inner split)", innerNoteDestID, innerSplit.ID)
 	}
 }
+
+// TestLoopCaptionPreserved covers the loop caption case — previously untested
+// per PR review. The fix for the outer-IF caption contamination bug also applied
+// the same snapshot/restore pattern to addLoopStatement and addWhileStatement.
+func TestLoopCaptionPreserved(t *testing.T) {
+	innerReturn := &ast.ReturnStmt{Value: &ast.LiteralExpr{Value: true, Kind: ast.LiteralBoolean}}
+	loop := &ast.LoopStmt{
+		LoopVariable: "item",
+		ListVariable: "items",
+		Body:         []ast.MicroflowStatement{innerReturn},
+		Annotations:  &ast.ActivityAnnotations{Caption: "Process each item"},
+	}
+
+	fb := &flowBuilder{
+		posX:         100,
+		posY:         100,
+		spacing:      HorizontalSpacing,
+		varTypes:     map[string]string{"items": "List of MyMod.Item"},
+		declaredVars: map[string]string{"items": "List of MyMod.Item"},
+	}
+	fb.buildFlowGraph([]ast.MicroflowStatement{loop}, nil)
+
+	var loops []*microflows.LoopedActivity
+	for _, obj := range fb.objects {
+		if l, ok := obj.(*microflows.LoopedActivity); ok {
+			loops = append(loops, l)
+		}
+	}
+
+	if len(loops) != 1 {
+		t.Fatalf("expected 1 LoopedActivity, got %d", len(loops))
+	}
+	if loops[0].Caption != "Process each item" {
+		t.Errorf("loop caption: got %q, want %q", loops[0].Caption, "Process each item")
+	}
+}
+
+// TestWhileLoopCaptionPreserved — same coverage for the WHILE shape.
+func TestWhileLoopCaptionPreserved(t *testing.T) {
+	whileStmt := &ast.WhileStmt{
+		Condition: &ast.BinaryExpr{
+			Left:     &ast.VariableExpr{Name: "n"},
+			Operator: "<",
+			Right:    &ast.LiteralExpr{Value: int64(10), Kind: ast.LiteralInteger},
+		},
+		Body: []ast.MicroflowStatement{
+			&ast.ReturnStmt{Value: &ast.LiteralExpr{Value: true, Kind: ast.LiteralBoolean}},
+		},
+		Annotations: &ast.ActivityAnnotations{Caption: "Until n >= 10"},
+	}
+
+	fb := &flowBuilder{
+		posX:         100,
+		posY:         100,
+		spacing:      HorizontalSpacing,
+		varTypes:     map[string]string{"n": "Integer"},
+		declaredVars: map[string]string{"n": "Integer"},
+	}
+	fb.buildFlowGraph([]ast.MicroflowStatement{whileStmt}, nil)
+
+	var loops []*microflows.LoopedActivity
+	for _, obj := range fb.objects {
+		if l, ok := obj.(*microflows.LoopedActivity); ok {
+			loops = append(loops, l)
+		}
+	}
+
+	if len(loops) != 1 {
+		t.Fatalf("expected 1 LoopedActivity (WHILE), got %d", len(loops))
+	}
+	if loops[0].Caption != "Until n >= 10" {
+		t.Errorf("while caption: got %q, want %q", loops[0].Caption, "Until n >= 10")
+	}
+}
+
+// TestInheritanceSplitCaptionApplied — InheritanceSplit is not produced by the
+// executor builder (only parsed from BSON for roundtrip), but applyAnnotations
+// gained an InheritanceSplit case in the fix. Test the applicator directly.
+func TestInheritanceSplitCaptionApplied(t *testing.T) {
+	split := &microflows.InheritanceSplit{}
+	split.ID = "inh-split-1"
+
+	fb := &flowBuilder{}
+	fb.objects = append(fb.objects, split)
+
+	fb.applyAnnotations(split.ID, &ast.ActivityAnnotations{Caption: "Customer type?"})
+
+	if split.Caption != "Customer type?" {
+		t.Errorf("inheritance split caption: got %q, want %q", split.Caption, "Customer type?")
+	}
+}

--- a/mdl/executor/cmd_microflows_builder_annotations_test.go
+++ b/mdl/executor/cmd_microflows_builder_annotations_test.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/mendixlabs/mxcli/mdl/ast"
+	"github.com/mendixlabs/mxcli/sdk/microflows"
+)
+
+// TestNestedIfPreservesCaptions is a regression test for the bug where
+// the outer IF's @caption would be overwritten by the inner IF's @caption
+// because pendingAnnotations is shared mutable state across recursive
+// addStatement calls.
+//
+// Before the fix:
+//   - outer ExclusiveSplit received caption "Right format?" (from inner IF)
+//   - inner ExclusiveSplit kept its condition expression as caption
+//   - inner IF's @annotation got attached to the outer split
+//
+// After the fix:
+//   - addIfStatement consumes its own pendingAnnotations right after
+//     creating its split, so outer and inner captions stay bound to the
+//     correct splits.
+func TestNestedIfPreservesCaptions(t *testing.T) {
+	// Build an AST equivalent to:
+	//   if $S != empty            @caption 'String not empty?'
+	//     if isMatch($S, 'x')     @caption 'Right format?'
+	//       return true
+	//     else
+	//       return false
+	//   else
+	//     return false
+	innerIf := &ast.IfStmt{
+		Condition: &ast.FunctionCallExpr{
+			Name:      "isMatch",
+			Arguments: []ast.Expression{&ast.VariableExpr{Name: "S"}, &ast.LiteralExpr{Value: "x", Kind: ast.LiteralString}},
+		},
+		ThenBody: []ast.MicroflowStatement{
+			&ast.ReturnStmt{Value: &ast.LiteralExpr{Value: true, Kind: ast.LiteralBoolean}},
+		},
+		ElseBody: []ast.MicroflowStatement{
+			&ast.ReturnStmt{Value: &ast.LiteralExpr{Value: false, Kind: ast.LiteralBoolean}},
+		},
+		Annotations: &ast.ActivityAnnotations{Caption: "Right format?"},
+	}
+	outerIf := &ast.IfStmt{
+		Condition: &ast.BinaryExpr{
+			Left:     &ast.VariableExpr{Name: "S"},
+			Operator: "!=",
+			Right:    &ast.LiteralExpr{Value: nil, Kind: ast.LiteralNull},
+		},
+		ThenBody: []ast.MicroflowStatement{innerIf},
+		ElseBody: []ast.MicroflowStatement{
+			&ast.ReturnStmt{Value: &ast.LiteralExpr{Value: false, Kind: ast.LiteralBoolean}},
+		},
+		Annotations: &ast.ActivityAnnotations{Caption: "String not empty?"},
+	}
+
+	fb := &flowBuilder{
+		posX:         100,
+		posY:         100,
+		spacing:      HorizontalSpacing,
+		varTypes:     map[string]string{"S": "String"},
+		declaredVars: map[string]string{"S": "String"},
+	}
+	fb.buildFlowGraph([]ast.MicroflowStatement{outerIf}, nil)
+
+	// Collect ExclusiveSplits with their captions. The outer split is created
+	// first, so objects[1] is the outer split (objects[0] is the StartEvent).
+	var splits []*microflows.ExclusiveSplit
+	for _, obj := range fb.objects {
+		if sp, ok := obj.(*microflows.ExclusiveSplit); ok {
+			splits = append(splits, sp)
+		}
+	}
+
+	if len(splits) != 2 {
+		t.Fatalf("expected 2 ExclusiveSplits, got %d", len(splits))
+	}
+
+	// Splits are appended in creation order: outer first (from outerIf),
+	// then inner (when recursion into ThenBody creates the nested IF's split).
+	outerSplit, innerSplit := splits[0], splits[1]
+
+	if outerSplit.Caption != "String not empty?" {
+		t.Errorf("outer split caption: got %q, want %q", outerSplit.Caption, "String not empty?")
+	}
+	if innerSplit.Caption != "Right format?" {
+		t.Errorf("inner split caption: got %q, want %q", innerSplit.Caption, "Right format?")
+	}
+}
+
+// TestIfCaptionWithoutNesting confirms a single IF with @caption still gets
+// the right caption after the fix (baseline sanity check).
+func TestIfCaptionWithoutNesting(t *testing.T) {
+	ifStmt := &ast.IfStmt{
+		Condition: &ast.BinaryExpr{
+			Left:     &ast.VariableExpr{Name: "S"},
+			Operator: "!=",
+			Right:    &ast.LiteralExpr{Value: nil, Kind: ast.LiteralNull},
+		},
+		ThenBody: []ast.MicroflowStatement{
+			&ast.ReturnStmt{Value: &ast.LiteralExpr{Value: true, Kind: ast.LiteralBoolean}},
+		},
+		ElseBody: []ast.MicroflowStatement{
+			&ast.ReturnStmt{Value: &ast.LiteralExpr{Value: false, Kind: ast.LiteralBoolean}},
+		},
+		Annotations: &ast.ActivityAnnotations{Caption: "String not empty?"},
+	}
+
+	fb := &flowBuilder{
+		posX:         100,
+		posY:         100,
+		spacing:      HorizontalSpacing,
+		varTypes:     map[string]string{"S": "String"},
+		declaredVars: map[string]string{"S": "String"},
+	}
+	fb.buildFlowGraph([]ast.MicroflowStatement{ifStmt}, nil)
+
+	for _, obj := range fb.objects {
+		if sp, ok := obj.(*microflows.ExclusiveSplit); ok {
+			if sp.Caption != "String not empty?" {
+				t.Errorf("split caption: got %q, want %q", sp.Caption, "String not empty?")
+			}
+			return
+		}
+	}
+	t.Fatal("no ExclusiveSplit found")
+}
+
+// TestIfAnnotationStaysWithCorrectSplit confirms @annotation on a nested IF
+// attaches to that IF's split, not to the outer one.
+func TestIfAnnotationStaysWithCorrectSplit(t *testing.T) {
+	innerIf := &ast.IfStmt{
+		Condition: &ast.FunctionCallExpr{
+			Name:      "isMatch",
+			Arguments: []ast.Expression{&ast.VariableExpr{Name: "S"}, &ast.LiteralExpr{Value: "x", Kind: ast.LiteralString}},
+		},
+		ThenBody: []ast.MicroflowStatement{
+			&ast.ReturnStmt{Value: &ast.LiteralExpr{Value: true, Kind: ast.LiteralBoolean}},
+		},
+		ElseBody: []ast.MicroflowStatement{
+			&ast.ReturnStmt{Value: &ast.LiteralExpr{Value: false, Kind: ast.LiteralBoolean}},
+		},
+		Annotations: &ast.ActivityAnnotations{
+			Caption:        "Right format?",
+			AnnotationText: "Inner IF note",
+		},
+	}
+	outerIf := &ast.IfStmt{
+		Condition: &ast.BinaryExpr{
+			Left:     &ast.VariableExpr{Name: "S"},
+			Operator: "!=",
+			Right:    &ast.LiteralExpr{Value: nil, Kind: ast.LiteralNull},
+		},
+		ThenBody: []ast.MicroflowStatement{innerIf},
+		ElseBody: []ast.MicroflowStatement{
+			&ast.ReturnStmt{Value: &ast.LiteralExpr{Value: false, Kind: ast.LiteralBoolean}},
+		},
+		Annotations: &ast.ActivityAnnotations{
+			Caption:        "String not empty?",
+			AnnotationText: "Outer IF note",
+		},
+	}
+
+	fb := &flowBuilder{
+		posX:         100,
+		posY:         100,
+		spacing:      HorizontalSpacing,
+		varTypes:     map[string]string{"S": "String"},
+		declaredVars: map[string]string{"S": "String"},
+	}
+	fb.buildFlowGraph([]ast.MicroflowStatement{outerIf}, nil)
+
+	var splits []*microflows.ExclusiveSplit
+	var annotations []*microflows.Annotation
+	for _, obj := range fb.objects {
+		switch o := obj.(type) {
+		case *microflows.ExclusiveSplit:
+			splits = append(splits, o)
+		case *microflows.Annotation:
+			annotations = append(annotations, o)
+		}
+	}
+
+	if len(splits) != 2 {
+		t.Fatalf("expected 2 splits, got %d", len(splits))
+	}
+	if len(annotations) != 2 {
+		t.Fatalf("expected 2 annotations, got %d", len(annotations))
+	}
+
+	outerSplit, innerSplit := splits[0], splits[1]
+
+	// AnnotationFlow links Annotation -> activity. Verify each flow points
+	// from the annotation with the expected text to the expected split.
+	var outerNoteDestID, innerNoteDestID string
+	for _, af := range fb.annotationFlows {
+		// Find the Annotation referenced by OriginID
+		for _, ann := range annotations {
+			if ann.ID != af.OriginID {
+				continue
+			}
+			switch ann.Caption {
+			case "Outer IF note":
+				outerNoteDestID = string(af.DestinationID)
+			case "Inner IF note":
+				innerNoteDestID = string(af.DestinationID)
+			}
+		}
+	}
+
+	if outerNoteDestID != string(outerSplit.ID) {
+		t.Errorf("outer note destination: got %q, want %q (outer split)", outerNoteDestID, outerSplit.ID)
+	}
+	if innerNoteDestID != string(innerSplit.ID) {
+		t.Errorf("inner note destination: got %q, want %q (inner split)", innerNoteDestID, innerSplit.ID)
+	}
+}

--- a/mdl/executor/cmd_microflows_builder_control.go
+++ b/mdl/executor/cmd_microflows_builder_control.go
@@ -62,6 +62,15 @@ func (fb *flowBuilder) addIfStatement(s *ast.IfStmt) model.ID {
 	fb.objects = append(fb.objects, split)
 	splitID := split.ID
 
+	// Apply this IF's own annotations (e.g. @caption, @annotation) to the split
+	// BEFORE recursing into branch bodies. Otherwise a nested statement's annotations
+	// would overwrite fb.pendingAnnotations (shared state) and the outer loop in
+	// buildFlowGraph would then attach the wrong caption/annotation to this split.
+	if fb.pendingAnnotations != nil {
+		fb.applyAnnotations(splitID, fb.pendingAnnotations)
+		fb.pendingAnnotations = nil
+	}
+
 	// Calculate merge position (after the longest branch)
 	mergeX := splitX + SplitWidth + HorizontalSpacing/2 + branchWidth + HorizontalSpacing/2
 
@@ -251,6 +260,12 @@ func (fb *flowBuilder) addIfStatement(s *ast.IfStmt) model.ID {
 // addLoopStatement creates a LOOP statement using LoopedActivity.
 // Layout: Auto-sizes the loop box to fit content with padding
 func (fb *flowBuilder) addLoopStatement(s *ast.LoopStmt) model.ID {
+	// Snapshot & clear this loop's own annotations so the body's recursive
+	// addStatement calls can't consume them. We re-apply to the loop activity
+	// after it's created below.
+	savedLoopAnnotations := fb.pendingAnnotations
+	fb.pendingAnnotations = nil
+
 	// First, measure the loop body to determine size
 	bodyBounds := fb.measurer.measureStatements(s.Body)
 
@@ -335,6 +350,11 @@ func (fb *flowBuilder) addLoopStatement(s *ast.LoopStmt) model.ID {
 	// This is how Mendix stores them - all flows at the microflow level
 	fb.flows = append(fb.flows, loopBuilder.flows...)
 
+	// Re-apply this loop's own annotations now that its activity exists.
+	if savedLoopAnnotations != nil {
+		fb.applyAnnotations(loop.ID, savedLoopAnnotations)
+	}
+
 	fb.posX += loopWidth + HorizontalSpacing
 
 	return loop.ID
@@ -343,6 +363,11 @@ func (fb *flowBuilder) addLoopStatement(s *ast.LoopStmt) model.ID {
 // addWhileStatement creates a WHILE loop using LoopedActivity with WhileLoopCondition.
 // Layout matches addLoopStatement but without iterator icon space.
 func (fb *flowBuilder) addWhileStatement(s *ast.WhileStmt) model.ID {
+	// Snapshot & clear this WHILE's own annotations so the body's recursive
+	// addStatement calls can't consume them (see addLoopStatement).
+	savedWhileAnnotations := fb.pendingAnnotations
+	fb.pendingAnnotations = nil
+
 	bodyBounds := fb.measurer.measureStatements(s.Body)
 
 	loopWidth := max(bodyBounds.Width+2*LoopPadding, MinLoopWidth)
@@ -402,6 +427,11 @@ func (fb *flowBuilder) addWhileStatement(s *ast.WhileStmt) model.ID {
 
 	fb.objects = append(fb.objects, loop)
 	fb.flows = append(fb.flows, loopBuilder.flows...)
+
+	if savedWhileAnnotations != nil {
+		fb.applyAnnotations(loop.ID, savedWhileAnnotations)
+	}
+
 	fb.posX += loopWidth + HorizontalSpacing
 
 	return loop.ID


### PR DESCRIPTION
## Summary

`@caption '...'` annotations on nested decisions (`if`) and loops were being dropped when the describer emitted MDL. The annotation state on the flow builder was overwritten by each child statement as it was processed, so when the outer loop in `buildFlowGraph` consumed the pending annotations for a parent, it picked up the wrong ones.

Fix snapshots each IF's / loop's own pending annotations into local scope before recursing into children, then re-applies them to the outer split/loop after the body is processed. Captions on nested control flow now round-trip.

Part of umbrella #257.

## Test plan

- [x] Regression test exercises `@caption` on nested `if` inside `loop` inside `if`.
- [x] `go build ./... && go test ./...` pass.

## Stack

This PR is the **base** of a 3-PR stack. The other two PRs build on it:

1. **This PR** — nested caption preservation (no dependencies).
2. #265 — rule-based decision subtype preservation (depends on this PR).
3. #266 — describer side of rule splits + free-floating annotations (depends on PR 2).

The stacking is needed because all three touch shared structs in the flow-graph builder; duplicating fields would produce nasty conflicts.
