### PR TITLE
fix: correct microflow body syntax in bug-test 258

### DIFF
--- a/mdl-examples/bug-tests/258-drop-create-microflow-unitid-preservation.mdl
+++ b/mdl-examples/bug-tests/258-drop-create-microflow-unitid-preservation.mdl
@@ -24,22 +24,26 @@
 
 create module BugTest258;
 
-create microflow BugTest258.MF_Original
-    returns string
-(
-    set $return = 'original'
-);
+create microflow BugTest258.MF_Original ()
+returns string as $result
+begin
+  declare $result string = 'original';
+  return $result;
+end;
+/
 
 -- Drop + recreate in the same session. Before the fix, this produced a
 -- dangling Unit row with a fresh UUID and the project became unopenable in
 -- Studio Pro. After the fix, the new microflow reuses the original UnitID.
 drop microflow BugTest258.MF_Original;
 
-create or modify microflow BugTest258.MF_Original
-    returns string
-(
-    set $return = 'replaced'
-);
+create or modify microflow BugTest258.MF_Original ()
+returns string as $result
+begin
+  declare $result string = 'replaced';
+  return $result;
+end;
+/
 
 -- DESCRIBE must round-trip cleanly (no placeholder UUIDs leaking).
 describe microflow BugTest258.MF_Original;


### PR DESCRIPTION
## Summary

The bug-test script that shipped with #258 (`mdl-examples/bug-tests/258-drop-create-microflow-unitid-preservation.mdl`) used the legacy paren-body microflow form:

```mdl
create microflow BugTest258.MF_Original
    returns string
(
    set $return = 'original'
);
```

The current MDL parser only accepts the `begin ... end;` form — the script fails `mxcli check` before it can ever be executed. Script is defanged as a regression artifact until the body is fixed.

This PR rewrites the two microflows with the `begin/end` form so the script parses. The functional payload — `DROP MICROFLOW`, then `CREATE OR MODIFY MICROFLOW` with the same qualified name to exercise `UnitID` preservation, then `DESCRIBE` to verify the roundtrip — is unchanged.

## Test plan

- [x] `mxcli check mdl-examples/bug-tests/258-drop-create-microflow-unitid-preservation.mdl` reports `Syntax OK (5 statements)`.
- [x] `go build ./... && go test ./...` pass.