### PR TITLE
refactor: remove ExecContext.executor back-pointer

### DIFF
--- a/mdl/executor/cmd_associations.go
+++ b/mdl/executor/cmd_associations.go
@@ -16,7 +16,6 @@ import (
 
 // execCreateAssociation handles CREATE ASSOCIATION statements.
 func execCreateAssociation(ctx *ExecContext, s *ast.CreateAssociationStmt) error {
-	e := ctx.executor
 	if !ctx.Connected() {
 		return mdlerrors.NewNotConnected()
 	}
@@ -138,7 +137,7 @@ func execCreateAssociation(ctx *ExecContext, s *ast.CreateAssociationStmt) error
 		}
 	}
 
-	e.trackModifiedDomainModel(module.ID, module.Name)
+	ctx.trackModifiedDomainModel(module.ID, module.Name)
 	fmt.Fprintf(ctx.Output, "Created association: %s\n", s.Name)
 	return nil
 }

--- a/mdl/executor/cmd_catalog.go
+++ b/mdl/executor/cmd_catalog.go
@@ -694,16 +694,6 @@ func captureDescribeParallel(ctx *ExecContext, objectType string, qualifiedName 
 		Cache:   ctx.Cache,
 		MprPath: ctx.MprPath,
 	}
-	// If a backing Executor exists, create a local one for handlers that still
-	// need e.backend/e.output (e.g., describeMicroflow via writeDescribeJSON).
-	if ctx.executor != nil {
-		local := &Executor{
-			backend: ctx.executor.backend,
-			output:  &buf,
-			cache:   ctx.Cache,
-		}
-		localCtx.executor = local
-	}
 
 	var err error
 	switch strings.ToLower(objectType) {

--- a/mdl/executor/cmd_catalog.go
+++ b/mdl/executor/cmd_catalog.go
@@ -454,7 +454,8 @@ func execRefreshCatalogStmt(ctx *ExecContext, stmt *ast.RefreshCatalogStmt) erro
 	// wrote to ctx.Output from the goroutine. A synchronized writer would
 	// fix this but is out of scope for the executor cleanup.
 	if stmt.Background {
-		bgCtx := *ctx // shallow copy — isolates Catalog, Cache, etc.
+		bgCtx := *ctx   // shallow copy — isolates scalar fields
+		bgCtx.Cache = nil // detach shared cache so preWarmCache writes stay local
 		go func() {
 			if err := buildCatalog(&bgCtx, stmt.Full, stmt.Source); err != nil {
 				fmt.Fprintf(bgCtx.Output, "Background catalog build failed: %v\n", err)

--- a/mdl/executor/cmd_catalog.go
+++ b/mdl/executor/cmd_catalog.go
@@ -285,7 +285,6 @@ func isCacheValid(ctx *ExecContext, cachePath string, requiredMode string) (bool
 
 // loadCachedCatalog loads a catalog from the cache file.
 func loadCachedCatalog(ctx *ExecContext, cachePath string) error {
-	e := ctx.executor
 	cat, err := catalog.NewFromFile(cachePath)
 	if err != nil {
 		return err
@@ -298,7 +297,6 @@ func loadCachedCatalog(ctx *ExecContext, cachePath string) error {
 	}
 
 	ctx.Catalog = cat
-	e.catalog = cat
 	if !ctx.Quiet {
 		age := time.Since(info.BuildTime)
 		fmt.Fprintf(ctx.Output, "Loading cached catalog (built %s ago, %s mode)...\n",
@@ -324,7 +322,6 @@ func formatDuration(d time.Duration) string {
 
 // buildCatalog builds the catalog from the project.
 func buildCatalog(ctx *ExecContext, full bool, source ...bool) error {
-	e := ctx.executor
 	isSource := len(source) > 0 && source[0]
 	if isSource {
 		full = true // source implies full
@@ -382,7 +379,6 @@ func buildCatalog(ctx *ExecContext, full bool, source ...bool) error {
 
 	cat.SetBuilt(true)
 	ctx.Catalog = cat
-	e.catalog = cat
 
 	if !ctx.Quiet {
 		fmt.Fprintf(ctx.Output, "✓ Catalog ready (%.1fs)\n", elapsed.Seconds())
@@ -408,7 +404,6 @@ func buildCatalog(ctx *ExecContext, full bool, source ...bool) error {
 
 // execRefreshCatalogStmt handles REFRESH CATALOG [FULL] [SOURCE] [FORCE] [BACKGROUND] command.
 func execRefreshCatalogStmt(ctx *ExecContext, stmt *ast.RefreshCatalogStmt) error {
-	e := ctx.executor
 	if !ctx.Connected() {
 		return mdlerrors.NewNotConnected()
 	}
@@ -431,7 +426,6 @@ func execRefreshCatalogStmt(ctx *ExecContext, stmt *ast.RefreshCatalogStmt) erro
 				if ctx.Catalog != nil {
 					ctx.Catalog.Close()
 					ctx.Catalog = nil
-					e.catalog = nil
 				}
 				return loadCachedCatalog(ctx, cachePath)
 			}
@@ -451,7 +445,6 @@ func execRefreshCatalogStmt(ctx *ExecContext, stmt *ast.RefreshCatalogStmt) erro
 	if ctx.Catalog != nil {
 		ctx.Catalog.Close()
 		ctx.Catalog = nil
-		e.catalog = nil
 	}
 
 	// Handle background mode

--- a/mdl/executor/cmd_catalog.go
+++ b/mdl/executor/cmd_catalog.go
@@ -447,11 +447,17 @@ func execRefreshCatalogStmt(ctx *ExecContext, stmt *ast.RefreshCatalogStmt) erro
 		ctx.Catalog = nil
 	}
 
-	// Handle background mode
+	// Handle background mode — clone ctx so the goroutine doesn't race
+	// with the main dispatch loop (which may syncBack and mutate fields).
+	// NOTE: bgCtx.Output still shares the underlying writer with the main
+	// goroutine. This is a pre-existing limitation — the original code also
+	// wrote to ctx.Output from the goroutine. A synchronized writer would
+	// fix this but is out of scope for the executor cleanup.
 	if stmt.Background {
+		bgCtx := *ctx // shallow copy — isolates Catalog, Cache, etc.
 		go func() {
-			if err := buildCatalog(ctx, stmt.Full, stmt.Source); err != nil {
-				fmt.Fprintf(ctx.Output, "Background catalog build failed: %v\n", err)
+			if err := buildCatalog(&bgCtx, stmt.Full, stmt.Source); err != nil {
+				fmt.Fprintf(bgCtx.Output, "Background catalog build failed: %v\n", err)
 			}
 		}()
 		fmt.Fprintln(ctx.Output, "Catalog build started in background...")

--- a/mdl/executor/cmd_entities.go
+++ b/mdl/executor/cmd_entities.go
@@ -46,7 +46,6 @@ func buildEventHandlers(ctx *ExecContext, defs []ast.EventHandlerDef) ([]*domain
 }
 
 func execCreateEntity(ctx *ExecContext, s *ast.CreateEntityStmt) error {
-	e := ctx.executor
 	if !ctx.Connected() {
 		return mdlerrors.NewNotConnected()
 	}
@@ -288,7 +287,7 @@ func execCreateEntity(ctx *ExecContext, s *ast.CreateEntityStmt) error {
 		fmt.Fprintf(ctx.Output, "Created entity: %s\n", s.Name)
 	}
 
-	e.trackModifiedDomainModel(module.ID, module.Name)
+	ctx.trackModifiedDomainModel(module.ID, module.Name)
 	return nil
 }
 
@@ -463,7 +462,6 @@ func execCreateViewEntity(ctx *ExecContext, s *ast.CreateViewEntityStmt) error {
 
 // execAlterEntity handles ALTER ENTITY statements.
 func execAlterEntity(ctx *ExecContext, s *ast.AlterEntityStmt) error {
-	e := ctx.executor
 	if !ctx.Connected() {
 		return mdlerrors.NewNotConnected()
 	}
@@ -911,7 +909,7 @@ func execAlterEntity(ctx *ExecContext, s *ast.AlterEntityStmt) error {
 		return mdlerrors.NewUnsupported("unsupported alter entity operation")
 	}
 
-	e.trackModifiedDomainModel(module.ID, module.Name)
+	ctx.trackModifiedDomainModel(module.ID, module.Name)
 	return nil
 }
 

--- a/mdl/executor/cmd_fragments.go
+++ b/mdl/executor/cmd_fragments.go
@@ -17,8 +17,6 @@ import (
 func execDefineFragment(ctx *ExecContext, s *ast.DefineFragmentStmt) error {
 	if ctx.Fragments == nil {
 		ctx.Fragments = make(map[string]*ast.DefineFragmentStmt)
-		// Also update the executor's fragments map so newExecContext picks it up.
-		ctx.executor.fragments = ctx.Fragments
 	}
 	if _, exists := ctx.Fragments[s.Name]; exists {
 		return mdlerrors.NewAlreadyExists("fragment", s.Name)

--- a/mdl/executor/cmd_lint.go
+++ b/mdl/executor/cmd_lint.go
@@ -15,7 +15,6 @@ import (
 
 // execLint executes a LINT statement.
 func execLint(ctx *ExecContext, s *ast.LintStmt) error {
-	e := ctx.executor
 	if !ctx.Connected() {
 		return mdlerrors.NewNotConnected()
 	}
@@ -35,7 +34,7 @@ func execLint(ctx *ExecContext, s *ast.LintStmt) error {
 
 	// Create lint context
 	lintCtx := linter.NewLintContext(ctx.Catalog)
-	lintCtx.SetReader(e.Reader())
+	lintCtx.SetReader(ctx.Reader())
 
 	// Load configuration
 	projectDir := filepath.Dir(ctx.MprPath)

--- a/mdl/executor/cmd_lint_mock_test.go
+++ b/mdl/executor/cmd_lint_mock_test.go
@@ -52,9 +52,9 @@ func TestLint_ShowRules(t *testing.T) {
 // ---------------------------------------------------------------------------
 // execLint — full lint path
 //
-// NOTE: The full lint path (ShowRules=false) requires ctx.executor,
+// NOTE: The full lint path (ShowRules=false) requires ctx.Reader(),
 // ctx.Catalog, buildCatalog, and the linter package pipeline. The current
-// mock infrastructure does not expose executor or catalog mocks, so only
+// mock infrastructure does not expose catalog mocks, so only
 // the ShowRules branch can be exercised. Expanding coverage requires
-// building executor/catalog mock support (tracked separately).
+// building catalog mock support (tracked separately).
 // ---------------------------------------------------------------------------

--- a/mdl/executor/cmd_microflows_create.go
+++ b/mdl/executor/cmd_microflows_create.go
@@ -33,7 +33,6 @@ func loadRestServices(ctx *ExecContext) ([]*model.ConsumedRestService, error) {
 }
 
 func execCreateMicroflow(ctx *ExecContext, s *ast.CreateMicroflowStmt) error {
-	e := ctx.executor
 	if !ctx.ConnectedForWrite() {
 		return mdlerrors.NewNotConnectedWrite()
 	}
@@ -268,7 +267,7 @@ func execCreateMicroflow(ctx *ExecContext, s *ast.CreateMicroflowStmt) error {
 
 	// Track the created microflow so it can be resolved by subsequent page creations
 	returnEntityName := extractEntityFromReturnType(mf.ReturnType)
-	e.trackCreatedMicroflow(s.Name.Module, s.Name.Name, mf.ID, containerID, returnEntityName)
+	ctx.trackCreatedMicroflow(s.Name.Module, s.Name.Name, mf.ID, containerID, returnEntityName)
 
 	// Invalidate hierarchy cache so the new microflow's container is visible
 	invalidateHierarchy(ctx)

--- a/mdl/executor/cmd_misc.go
+++ b/mdl/executor/cmd_misc.go
@@ -392,7 +392,6 @@ func execExit(ctx *ExecContext) error {
 
 // execExecuteScript handles EXECUTE SCRIPT statements.
 func execExecuteScript(ctx *ExecContext, s *ast.ExecuteScriptStmt) error {
-	e := ctx.executor
 	// Resolve path relative to current working directory
 	scriptPath := s.Path
 	if !filepath.IsAbs(scriptPath) {
@@ -425,7 +424,7 @@ func execExecuteScript(ctx *ExecContext, s *ast.ExecuteScriptStmt) error {
 	// Execute all statements in the script
 	fmt.Fprintf(ctx.Output, "Executing script: %s\n", s.Path)
 	for _, stmt := range prog.Statements {
-		if err := e.Execute(stmt); err != nil {
+		if err := ctx.ExecuteFn(stmt); err != nil {
 			// Exit within a script just stops the script, doesn't exit mxcli
 			if errors.Is(err, ErrExit) {
 				fmt.Fprintf(ctx.Output, "Script exited: %s\n", s.Path)

--- a/mdl/executor/cmd_misc.go
+++ b/mdl/executor/cmd_misc.go
@@ -423,6 +423,9 @@ func execExecuteScript(ctx *ExecContext, s *ast.ExecuteScriptStmt) error {
 
 	// Execute all statements in the script
 	fmt.Fprintf(ctx.Output, "Executing script: %s\n", s.Path)
+	if ctx.ExecuteFn == nil {
+		return mdlerrors.NewBackend("execute script", errors.New("no statement dispatcher configured"))
+	}
 	for _, stmt := range prog.Statements {
 		if err := ctx.ExecuteFn(stmt); err != nil {
 			// Exit within a script just stops the script, doesn't exit mxcli

--- a/mdl/executor/cmd_misc.go
+++ b/mdl/executor/cmd_misc.go
@@ -424,7 +424,7 @@ func execExecuteScript(ctx *ExecContext, s *ast.ExecuteScriptStmt) error {
 	// Execute all statements in the script
 	fmt.Fprintf(ctx.Output, "Executing script: %s\n", s.Path)
 	if ctx.ExecuteFn == nil {
-		return mdlerrors.NewBackend("execute script", errors.New("no statement dispatcher configured"))
+		return mdlerrors.NewBackend("execute script", errors.New("ExecuteFn not set — ExecContext was not created via Executor dispatch"))
 	}
 	for _, stmt := range prog.Statements {
 		if err := ctx.ExecuteFn(stmt); err != nil {

--- a/mdl/executor/cmd_misc.go
+++ b/mdl/executor/cmd_misc.go
@@ -41,10 +41,6 @@ func execRefresh(ctx *ExecContext) error {
 func execSet(ctx *ExecContext, s *ast.SetStmt) error {
 	if ctx.Settings == nil {
 		ctx.Settings = make(map[string]any)
-		// Persist back to Executor so subsequent statements see the map.
-		if ctx.executor != nil {
-			ctx.executor.settings = ctx.Settings
-		}
 	}
 	ctx.Settings[s.Key] = s.Value
 	fmt.Fprintf(ctx.Output, "Set %s = %v\n", s.Key, s.Value)

--- a/mdl/executor/cmd_pages_create_v3.go
+++ b/mdl/executor/cmd_pages_create_v3.go
@@ -16,7 +16,6 @@ import (
 
 // execCreatePageV3 handles CREATE PAGE statement with V3 syntax.
 func execCreatePageV3(ctx *ExecContext, s *ast.CreatePageStmtV3) error {
-	e := ctx.executor
 	if !ctx.ConnectedForWrite() {
 		return mdlerrors.NewNotConnectedWrite()
 	}
@@ -90,7 +89,7 @@ func execCreatePageV3(ctx *ExecContext, s *ast.CreatePageStmtV3) error {
 	}
 
 	// Track the created page so it can be resolved by subsequent page references
-	e.trackCreatedPage(s.Name.Module, s.Name.Name, page.ID, moduleID)
+	ctx.trackCreatedPage(s.Name.Module, s.Name.Name, page.ID, moduleID)
 
 	// Invalidate hierarchy cache so the new page's container is visible
 	invalidateHierarchy(ctx)
@@ -101,7 +100,6 @@ func execCreatePageV3(ctx *ExecContext, s *ast.CreatePageStmtV3) error {
 
 // execCreateSnippetV3 handles CREATE SNIPPET statement with V3 syntax.
 func execCreateSnippetV3(ctx *ExecContext, s *ast.CreateSnippetStmtV3) error {
-	e := ctx.executor
 	if !ctx.ConnectedForWrite() {
 		return mdlerrors.NewNotConnectedWrite()
 	}
@@ -159,7 +157,7 @@ func execCreateSnippetV3(ctx *ExecContext, s *ast.CreateSnippetStmtV3) error {
 	}
 
 	// Track the created snippet so it can be resolved by subsequent snippet references
-	e.trackCreatedSnippet(s.Name.Module, s.Name.Name, snippet.ID, moduleID)
+	ctx.trackCreatedSnippet(s.Name.Module, s.Name.Name, snippet.ID, moduleID)
 
 	// Invalidate hierarchy cache so the new snippet's container is visible
 	invalidateHierarchy(ctx)

--- a/mdl/executor/cmd_security_write.go
+++ b/mdl/executor/cmd_security_write.go
@@ -277,7 +277,6 @@ func execDropUserRole(ctx *ExecContext, s *ast.DropUserRoleStmt) error {
 
 // execGrantEntityAccess handles GRANT roles ON Module.Entity (rights) [WHERE '...'].
 func execGrantEntityAccess(ctx *ExecContext, s *ast.GrantEntityAccessStmt) error {
-	e := ctx.executor
 	if !ctx.ConnectedForWrite() {
 		return mdlerrors.NewNotConnectedWrite()
 	}
@@ -431,7 +430,7 @@ func execGrantEntityAccess(ctx *ExecContext, s *ast.GrantEntityAccessStmt) error
 		fmt.Fprintf(ctx.Output, "Reconciled %d access rule(s) in module %s\n", count, module.Name)
 	}
 
-	e.trackModifiedDomainModel(module.ID, module.Name)
+	ctx.trackModifiedDomainModel(module.ID, module.Name)
 	fmt.Fprintf(ctx.Output, "Granted access on %s.%s to %s\n", s.Entity.Module, s.Entity.Name, strings.Join(roleNames, ", "))
 	if !ctx.Quiet {
 		fmt.Fprint(ctx.Output, formatAccessRuleResult(ctx, s.Entity.Module, s.Entity.Name, roleNames))
@@ -441,7 +440,6 @@ func execGrantEntityAccess(ctx *ExecContext, s *ast.GrantEntityAccessStmt) error
 
 // execRevokeEntityAccess handles REVOKE roles ON Module.Entity [(rights...)].
 func execRevokeEntityAccess(ctx *ExecContext, s *ast.RevokeEntityAccessStmt) error {
-	e := ctx.executor
 	if !ctx.ConnectedForWrite() {
 		return mdlerrors.NewNotConnectedWrite()
 	}
@@ -523,7 +521,7 @@ func execRevokeEntityAccess(ctx *ExecContext, s *ast.RevokeEntityAccessStmt) err
 			}
 		}
 	}
-	e.trackModifiedDomainModel(module.ID, module.Name)
+	ctx.trackModifiedDomainModel(module.ID, module.Name)
 	return nil
 }
 

--- a/mdl/executor/cmd_sql.go
+++ b/mdl/executor/cmd_sql.go
@@ -238,12 +238,11 @@ func execSQLGenerateConnector(ctx *ExecContext, s *ast.SQLGenerateConnectorStmt)
 
 // executeGeneratedMDL parses and executes MDL text as if it were a script.
 func executeGeneratedMDL(ctx *ExecContext, mdl string) error {
-	e := ctx.executor
 	prog, errs := visitor.Build(mdl)
 	if len(errs) > 0 {
 		return mdlerrors.NewBackend("parse generated MDL", fmt.Errorf("%v", errs[0]))
 	}
-	return e.ExecuteProgram(prog)
+	return ctx.ExecuteProgramFn(prog)
 }
 
 // execSQLDescribeTable handles SQL <alias> DESCRIBE <table>

--- a/mdl/executor/cmd_sql.go
+++ b/mdl/executor/cmd_sql.go
@@ -16,11 +16,7 @@ import (
 
 // ensureSQLManager lazily initializes the SQL connection manager.
 func ensureSQLManager(ctx *ExecContext) *sqllib.Manager {
-	e := ctx.executor
-	if e.sqlMgr == nil {
-		e.sqlMgr = sqllib.NewManager()
-	}
-	return e.sqlMgr
+	return ctx.EnsureSqlMgr()
 }
 
 // getOrAutoConnect returns an existing connection or auto-connects using connections.yaml.

--- a/mdl/executor/cmd_sql.go
+++ b/mdl/executor/cmd_sql.go
@@ -243,7 +243,7 @@ func executeGeneratedMDL(ctx *ExecContext, mdl string) error {
 		return mdlerrors.NewBackend("parse generated MDL", fmt.Errorf("%v", errs[0]))
 	}
 	if ctx.ExecuteProgramFn == nil {
-		return mdlerrors.NewBackend("execute generated MDL", fmt.Errorf("no program dispatcher configured"))
+		return mdlerrors.NewBackend("execute generated MDL", fmt.Errorf("ExecuteProgramFn not set — ExecContext was not created via Executor dispatch"))
 	}
 	return ctx.ExecuteProgramFn(prog)
 }

--- a/mdl/executor/cmd_sql.go
+++ b/mdl/executor/cmd_sql.go
@@ -242,6 +242,9 @@ func executeGeneratedMDL(ctx *ExecContext, mdl string) error {
 	if len(errs) > 0 {
 		return mdlerrors.NewBackend("parse generated MDL", fmt.Errorf("%v", errs[0]))
 	}
+	if ctx.ExecuteProgramFn == nil {
+		return mdlerrors.NewBackend("execute generated MDL", fmt.Errorf("no program dispatcher configured"))
+	}
 	return ctx.ExecuteProgramFn(prog)
 }
 

--- a/mdl/executor/cmd_write_handlers_mock_test.go
+++ b/mdl/executor/cmd_write_handlers_mock_test.go
@@ -499,16 +499,14 @@ func TestDropThenCreatePreservesMicroflowUnitID(t *testing.T) {
 		},
 	}
 
-	// Need an Executor so ctx.executor is set (trackCreatedMicroflow uses it).
-	exec := New(&bytesWriter{})
+	// Create ExecContext directly — trackCreatedMicroflow is now a method on ExecContext.
+	var out bytesWriter
 	ctx := &ExecContext{
-		Context:  t.Context(),
-		Backend:  mb,
-		Output:   exec.output,
-		Format:   FormatTable,
-		executor: exec,
+		Context: t.Context(),
+		Backend: mb,
+		Output:  &out,
+		Format:  FormatTable,
 	}
-	exec.backend = mb
 	withHierarchy(h)(ctx)
 
 	if err := execDropMicroflow(ctx, &ast.DropMicroflowStmt{
@@ -582,13 +580,11 @@ func TestCreateOrModifyMicroflowPreservesAllowedRoles(t *testing.T) {
 
 	exec := New(&bytesWriter{})
 	ctx := &ExecContext{
-		Context:  t.Context(),
-		Backend:  mb,
-		Output:   exec.output,
-		Format:   FormatTable,
-		executor: exec,
+		Context: t.Context(),
+		Backend: mb,
+		Output:  exec.output,
+		Format:  FormatTable,
 	}
-	exec.backend = mb
 	withHierarchy(h)(ctx)
 
 	if err := execCreateMicroflow(ctx, &ast.CreateMicroflowStmt{

--- a/mdl/executor/exec_context.go
+++ b/mdl/executor/exec_context.go
@@ -65,11 +65,23 @@ type ExecContext struct {
 	// Settings holds session-scoped key-value settings (SET command).
 	Settings map[string]any
 
-	// executor is a temporary back-reference used during incremental migration.
-	// Handlers that have not yet been migrated to use Backend can access the
-	// original Executor through this field. Remove once all handlers are fully
-	// migrated to ctx.Backend (tracked: ~7 e := ctx.executor sites remain).
-	executor *Executor
+	// BackendFactory creates new backend instances (used by connect/reconnect).
+	BackendFactory BackendFactory
+
+	// OutputGuard is the line-limit guard wrapping Output (nil-safe).
+	// Used by writeDescribeJSON to temporarily disable line limiting during capture.
+	OutputGuard *outputGuard
+
+	// ExecuteFn dispatches a single statement through the Executor's full
+	// pipeline (line-limit reset, wall-clock timeout, logging). Set by
+	// newExecContext; used by script execution and generated-MDL dispatch.
+	ExecuteFn func(ast.Statement) error
+
+	// ExecuteProgramFn dispatches a full program (all statements + finalization).
+	ExecuteProgramFn func(*ast.Program) error
+
+	// FinalizeFn runs post-execution reconciliation (security rule sync).
+	FinalizeFn func() error
 }
 
 // Connected returns true if a project is connected via the Backend.

--- a/mdl/executor/exec_context.go
+++ b/mdl/executor/exec_context.go
@@ -216,7 +216,8 @@ func (ctx *ExecContext) EnsureSqlMgr() *sqllib.Manager {
 }
 
 // Reader returns the MPR reader, or nil if not connected.
-// Deprecated: Callers should migrate to Backend methods directly.
+// Deprecated: External callers should migrate to using Backend methods directly.
+// TODO(shared-types): remove once all callers use Backend — target: v0.next milestone.
 func (ctx *ExecContext) Reader() *mpr.Reader {
 	if ctx.Backend == nil {
 		return nil

--- a/mdl/executor/exec_context.go
+++ b/mdl/executor/exec_context.go
@@ -11,6 +11,8 @@ import (
 	"github.com/mendixlabs/mxcli/mdl/backend"
 	"github.com/mendixlabs/mxcli/mdl/catalog"
 	"github.com/mendixlabs/mxcli/mdl/diaglog"
+	"github.com/mendixlabs/mxcli/model"
+	"github.com/mendixlabs/mxcli/sdk/mpr"
 	sqllib "github.com/mendixlabs/mxcli/sql"
 )
 
@@ -66,7 +68,7 @@ type ExecContext struct {
 	// executor is a temporary back-reference used during incremental migration.
 	// Handlers that have not yet been migrated to use Backend can access the
 	// original Executor through this field. Remove once all handlers are fully
-	// migrated to ctx.Backend (tracked: ~27 e := ctx.executor sites remain).
+	// migrated to ctx.Backend (tracked: ~7 e := ctx.executor sites remain).
 	executor *Executor
 }
 
@@ -82,14 +84,10 @@ func (ctx *ExecContext) ConnectedForWrite() bool {
 	return ctx.Connected()
 }
 
-// InvalidateCache clears the hierarchy/entity/microflow cache on both the
-// ExecContext and the underlying Executor so that subsequent statements see
-// fresh data.
+// InvalidateCache clears the hierarchy/entity/microflow cache so that
+// subsequent statements see fresh data.
 func (ctx *ExecContext) InvalidateCache() {
 	ctx.Cache = nil
-	if ctx.executor != nil {
-		ctx.executor.cache = nil
-	}
 }
 
 // GetThemeRegistry returns the cached theme registry, loading it lazily
@@ -110,10 +108,112 @@ func (ctx *ExecContext) GetThemeRegistry() *ThemeRegistry {
 		return nil
 	}
 	ctx.ThemeRegistry = registry
-	// Persist back to Executor so subsequent statements pick up the cached value
-	// via newExecContext without reloading.
-	if ctx.executor != nil {
-		ctx.executor.themeRegistry = registry
-	}
 	return ctx.ThemeRegistry
+}
+
+// ensureCache initializes the ExecContext cache if nil.
+func (ctx *ExecContext) ensureCache() {
+	if ctx.Cache == nil {
+		ctx.Cache = &executorCache{}
+	}
+}
+
+// trackModifiedDomainModel records a domain model that was modified during
+// execution, so it can be reconciled at the end of the program.
+func (ctx *ExecContext) trackModifiedDomainModel(moduleID model.ID, moduleName string) {
+	if ctx.Backend == nil || !ctx.Backend.IsConnected() {
+		return
+	}
+	ctx.ensureCache()
+	if ctx.Cache.modifiedDomainModels == nil {
+		ctx.Cache.modifiedDomainModels = make(map[model.ID]string)
+	}
+	ctx.Cache.modifiedDomainModels[moduleID] = moduleName
+}
+
+// trackCreatedMicroflow registers a microflow created during this session.
+func (ctx *ExecContext) trackCreatedMicroflow(moduleName, mfName string, id, containerID model.ID, returnEntityName string) {
+	ctx.ensureCache()
+	if ctx.Cache.createdMicroflows == nil {
+		ctx.Cache.createdMicroflows = make(map[string]*createdMicroflowInfo)
+	}
+	qualifiedName := moduleName + "." + mfName
+	ctx.Cache.createdMicroflows[qualifiedName] = &createdMicroflowInfo{
+		ID:               id,
+		Name:             mfName,
+		ModuleName:       moduleName,
+		ContainerID:      containerID,
+		ReturnEntityName: returnEntityName,
+	}
+}
+
+// trackCreatedPage registers a page created during this session.
+func (ctx *ExecContext) trackCreatedPage(moduleName, pageName string, id, containerID model.ID) {
+	ctx.ensureCache()
+	if ctx.Cache.createdPages == nil {
+		ctx.Cache.createdPages = make(map[string]*createdPageInfo)
+	}
+	qualifiedName := moduleName + "." + pageName
+	ctx.Cache.createdPages[qualifiedName] = &createdPageInfo{
+		ID:          id,
+		Name:        pageName,
+		ModuleName:  moduleName,
+		ContainerID: containerID,
+	}
+}
+
+// trackCreatedSnippet registers a snippet created during this session.
+func (ctx *ExecContext) trackCreatedSnippet(moduleName, snippetName string, id, containerID model.ID) {
+	ctx.ensureCache()
+	if ctx.Cache.createdSnippets == nil {
+		ctx.Cache.createdSnippets = make(map[string]*createdSnippetInfo)
+	}
+	qualifiedName := moduleName + "." + snippetName
+	ctx.Cache.createdSnippets[qualifiedName] = &createdSnippetInfo{
+		ID:          id,
+		Name:        snippetName,
+		ModuleName:  moduleName,
+		ContainerID: containerID,
+	}
+}
+
+// getCreatedMicroflow returns info about a microflow created during this
+// session, or nil if not found.
+func (ctx *ExecContext) getCreatedMicroflow(qualifiedName string) *createdMicroflowInfo {
+	if ctx.Cache == nil || ctx.Cache.createdMicroflows == nil {
+		return nil
+	}
+	return ctx.Cache.createdMicroflows[qualifiedName]
+}
+
+// getCreatedPage returns info about a page created during this session,
+// or nil if not found.
+func (ctx *ExecContext) getCreatedPage(qualifiedName string) *createdPageInfo {
+	if ctx.Cache == nil || ctx.Cache.createdPages == nil {
+		return nil
+	}
+	return ctx.Cache.createdPages[qualifiedName]
+}
+
+// EnsureSqlMgr lazily initializes and returns the SQL connection manager.
+func (ctx *ExecContext) EnsureSqlMgr() *sqllib.Manager {
+	if ctx.SqlMgr == nil {
+		ctx.SqlMgr = sqllib.NewManager()
+	}
+	return ctx.SqlMgr
+}
+
+// Reader returns the MPR reader, or nil if not connected.
+// Deprecated: Callers should migrate to Backend methods directly.
+func (ctx *ExecContext) Reader() *mpr.Reader {
+	if ctx.Backend == nil {
+		return nil
+	}
+	type readerProvider interface {
+		MprReader() *mpr.Reader
+	}
+	if rp, ok := ctx.Backend.(readerProvider); ok {
+		return rp.MprReader()
+	}
+	return nil
 }

--- a/mdl/executor/exec_context.go
+++ b/mdl/executor/exec_context.go
@@ -68,10 +68,6 @@ type ExecContext struct {
 	// BackendFactory creates new backend instances (used by connect/reconnect).
 	BackendFactory BackendFactory
 
-	// OutputGuard is the line-limit guard wrapping Output (nil-safe).
-	// Used by writeDescribeJSON to temporarily disable line limiting during capture.
-	OutputGuard *outputGuard
-
 	// ExecuteFn dispatches a single statement through the Executor's full
 	// pipeline (line-limit reset, wall-clock timeout, logging). Set by
 	// newExecContext; used by script execution and generated-MDL dispatch.

--- a/mdl/executor/executor.go
+++ b/mdl/executor/executor.go
@@ -272,22 +272,6 @@ func (e *Executor) ExecuteProgram(prog *ast.Program) error {
 	return e.finalizeProgramExecution()
 }
 
-// trackModifiedDomainModel records a domain model that was modified during execution,
-// so it can be reconciled at the end of the program.
-func (e *Executor) trackModifiedDomainModel(moduleID model.ID, moduleName string) {
-	if e.backend == nil || !e.backend.IsConnected() {
-		return
-	}
-	if e.cache == nil {
-		e.cache = &executorCache{}
-	}
-	if e.cache.modifiedDomainModels == nil {
-		e.cache.modifiedDomainModels = make(map[model.ID]string)
-	}
-	// We store the module ID as key temporarily; we'll resolve to DM ID during finalization
-	e.cache.modifiedDomainModels[moduleID] = moduleName
-}
-
 // finalizeProgramExecution runs post-execution reconciliation on modified domain models.
 func (e *Executor) finalizeProgramExecution() error {
 	if e.backend == nil || !e.backend.IsConnected() || e.cache == nil || len(e.cache.modifiedDomainModels) == 0 {
@@ -357,83 +341,6 @@ func (e *Executor) Close() error {
 // ----------------------------------------------------------------------------
 // Cache and Tracking
 // ----------------------------------------------------------------------------
-
-// trackCreatedMicroflow registers a microflow that was created during this session.
-// This allows subsequent page creations to resolve references to the microflow
-// even though the backend cache hasn't been updated.
-func (e *Executor) trackCreatedMicroflow(moduleName, mfName string, id, containerID model.ID, returnEntityName string) {
-	e.ensureCache()
-	if e.cache.createdMicroflows == nil {
-		e.cache.createdMicroflows = make(map[string]*createdMicroflowInfo)
-	}
-	qualifiedName := moduleName + "." + mfName
-	e.cache.createdMicroflows[qualifiedName] = &createdMicroflowInfo{
-		ID:               id,
-		Name:             mfName,
-		ModuleName:       moduleName,
-		ContainerID:      containerID,
-		ReturnEntityName: returnEntityName,
-	}
-}
-
-// trackCreatedPage registers a page that was created during this session.
-// This allows subsequent page creations to resolve SHOW_PAGE references
-// even though the backend cache hasn't been updated.
-func (e *Executor) trackCreatedPage(moduleName, pageName string, id, containerID model.ID) {
-	e.ensureCache()
-	if e.cache.createdPages == nil {
-		e.cache.createdPages = make(map[string]*createdPageInfo)
-	}
-	qualifiedName := moduleName + "." + pageName
-	e.cache.createdPages[qualifiedName] = &createdPageInfo{
-		ID:          id,
-		Name:        pageName,
-		ModuleName:  moduleName,
-		ContainerID: containerID,
-	}
-}
-
-// trackCreatedSnippet registers a snippet that was created during this session.
-// This allows subsequent creations to resolve snippet references
-// even though the backend cache hasn't been updated.
-func (e *Executor) trackCreatedSnippet(moduleName, snippetName string, id, containerID model.ID) {
-	e.ensureCache()
-	if e.cache.createdSnippets == nil {
-		e.cache.createdSnippets = make(map[string]*createdSnippetInfo)
-	}
-	qualifiedName := moduleName + "." + snippetName
-	e.cache.createdSnippets[qualifiedName] = &createdSnippetInfo{
-		ID:          id,
-		Name:        snippetName,
-		ModuleName:  moduleName,
-		ContainerID: containerID,
-	}
-}
-
-// getCreatedMicroflow returns info about a microflow created during this session,
-// or nil if not found.
-func (e *Executor) getCreatedMicroflow(qualifiedName string) *createdMicroflowInfo {
-	if e.cache == nil || e.cache.createdMicroflows == nil {
-		return nil
-	}
-	return e.cache.createdMicroflows[qualifiedName]
-}
-
-// getCreatedPage returns info about a page created during this session,
-// or nil if not found.
-func (e *Executor) getCreatedPage(qualifiedName string) *createdPageInfo {
-	if e.cache == nil || e.cache.createdPages == nil {
-		return nil
-	}
-	return e.cache.createdPages[qualifiedName]
-}
-
-// ensureCache initializes the executor cache if not already initialized.
-func (e *Executor) ensureCache() {
-	if e.cache == nil {
-		e.cache = &executorCache{}
-	}
-}
 
 // rememberDroppedMicroflow records the UnitID and ContainerID of a microflow
 // that is about to be deleted via DROP MICROFLOW. A follow-up CREATE OR

--- a/mdl/executor/executor.go
+++ b/mdl/executor/executor.go
@@ -447,9 +447,6 @@ func rememberDroppedMicroflow(ctx *ExecContext, qualifiedName string, id, contai
 	}
 	if ctx.Cache == nil {
 		ctx.Cache = &executorCache{}
-		if ctx.executor != nil {
-			ctx.executor.cache = ctx.Cache
-		}
 	}
 	if ctx.Cache.droppedMicroflows == nil {
 		ctx.Cache.droppedMicroflows = make(map[string]*droppedUnitInfo)

--- a/mdl/executor/executor_connect.go
+++ b/mdl/executor/executor_connect.go
@@ -11,40 +11,31 @@ import (
 )
 
 func execConnect(ctx *ExecContext, s *ast.ConnectStmt) error {
-	e := ctx.executor
-	if e.backend != nil && e.backend.IsConnected() {
-		if err := e.backend.Disconnect(); err != nil {
+	if ctx.Backend != nil && ctx.Backend.IsConnected() {
+		if err := ctx.Backend.Disconnect(); err != nil {
 			fmt.Fprintf(ctx.Output, "Warning: disconnect error: %v\n", err)
 		}
 	}
 
-	if e.backendFactory == nil {
+	if ctx.BackendFactory == nil {
 		return mdlerrors.NewBackend("connect", errors.New("no backend factory configured"))
 	}
-	b := e.backendFactory()
+	b := ctx.BackendFactory()
 	if err := b.Connect(s.Path); err != nil {
 		return mdlerrors.NewBackend("connect", err)
 	}
 
-	e.backend = b
-	e.mprPath = s.Path
-	e.cache = &executorCache{} // Initialize fresh cache
-
-	// Propagate connection state back to ctx so subsequent code in this
-	// dispatch cycle sees the updated values.
-	ctx.Backend = e.backend
-	ctx.Cache = e.cache
-	ctx.MprPath = e.mprPath
+	ctx.Backend = b
+	ctx.MprPath = s.Path
+	ctx.Cache = &executorCache{} // Initialize fresh cache
 
 	// Reset project-scoped caches — previous project's catalog and theme
 	// registry are invalid for the new connection.
-	e.catalog = nil
-	e.themeRegistry = nil
 	ctx.Catalog = nil
 	ctx.ThemeRegistry = nil
 
 	// Display connection info with version
-	pv := e.backend.ProjectVersion()
+	pv := ctx.Backend.ProjectVersion()
 	if !ctx.Quiet {
 		fmt.Fprintf(ctx.Output, "Connected to: %s (Mendix %s)\n", s.Path, pv.ProductVersion)
 	}
@@ -57,37 +48,30 @@ func execConnect(ctx *ExecContext, s *ast.ConnectStmt) error {
 // reconnect closes the current connection and reopens it.
 // This is needed when the project file has been modified externally.
 func reconnect(ctx *ExecContext) error {
-	e := ctx.executor
-	if e.mprPath == "" {
+	if ctx.MprPath == "" {
 		return mdlerrors.NewNotConnected()
 	}
 
 	// Close existing connection
-	if e.backend != nil && e.backend.IsConnected() {
-		if err := e.backend.Disconnect(); err != nil {
+	if ctx.Backend != nil && ctx.Backend.IsConnected() {
+		if err := ctx.Backend.Disconnect(); err != nil {
 			fmt.Fprintf(ctx.Output, "Warning: disconnect error: %v\n", err)
 		}
 	}
 
 	// Reopen connection
-	if e.backendFactory == nil {
+	if ctx.BackendFactory == nil {
 		return mdlerrors.NewBackend("reconnect", fmt.Errorf("no backend factory configured"))
 	}
-	b := e.backendFactory()
-	if err := b.Connect(e.mprPath); err != nil {
+	b := ctx.BackendFactory()
+	if err := b.Connect(ctx.MprPath); err != nil {
 		return mdlerrors.NewBackend("reconnect", err)
 	}
 
-	e.backend = b
-	e.cache = &executorCache{} // Reset cache
-
-	// Propagate reconnection state back to ctx.
-	ctx.Backend = e.backend
-	ctx.Cache = e.cache
+	ctx.Backend = b
+	ctx.Cache = &executorCache{} // Reset cache
 
 	// Reset project-scoped caches — file may have changed externally.
-	e.catalog = nil
-	e.themeRegistry = nil
 	ctx.Catalog = nil
 	ctx.ThemeRegistry = nil
 
@@ -95,52 +79,43 @@ func reconnect(ctx *ExecContext) error {
 }
 
 func execDisconnect(ctx *ExecContext) error {
-	e := ctx.executor
-	if e.backend == nil || !e.backend.IsConnected() {
+	if ctx.Backend == nil || !ctx.Backend.IsConnected() {
 		fmt.Fprintln(ctx.Output, "Not connected")
 		return nil
 	}
 
 	// Reconcile any pending security changes before closing
-	if err := e.finalizeProgramExecution(); err != nil {
-		fmt.Fprintf(ctx.Output, "Warning: finalization error: %v\n", err)
+	if ctx.FinalizeFn != nil {
+		if err := ctx.FinalizeFn(); err != nil {
+			fmt.Fprintf(ctx.Output, "Warning: finalization error: %v\n", err)
+		}
 	}
 
-	if err := e.backend.Disconnect(); err != nil {
+	if err := ctx.Backend.Disconnect(); err != nil {
 		fmt.Fprintf(ctx.Output, "Warning: disconnect error: %v\n", err)
 	}
-	fmt.Fprintf(ctx.Output, "Disconnected from: %s\n", e.mprPath)
-	e.mprPath = ""
-	e.cache = nil
-	e.backend = nil
-
-	// Propagate disconnection state back to ctx so subsequent code in this
-	// dispatch cycle sees the cleared values.
-	ctx.Backend = nil
+	fmt.Fprintf(ctx.Output, "Disconnected from: %s\n", ctx.MprPath)
 	ctx.MprPath = ""
 	ctx.Cache = nil
+	ctx.Backend = nil
 
 	return nil
 }
 
-// Executor method wrappers — kept during migration for callers not yet
-// converted to free functions. Remove once all callers are migrated.
-
 func execStatus(ctx *ExecContext) error {
-	e := ctx.executor
-	if e.backend == nil || !e.backend.IsConnected() {
+	if ctx.Backend == nil || !ctx.Backend.IsConnected() {
 		fmt.Fprintln(ctx.Output, "Status: Not connected")
 		return nil
 	}
 
-	pv := e.backend.ProjectVersion()
+	pv := ctx.Backend.ProjectVersion()
 	fmt.Fprintf(ctx.Output, "Status: Connected\n")
-	fmt.Fprintf(ctx.Output, "Project: %s\n", e.mprPath)
+	fmt.Fprintf(ctx.Output, "Project: %s\n", ctx.MprPath)
 	fmt.Fprintf(ctx.Output, "Mendix Version: %s\n", pv.ProductVersion)
 	fmt.Fprintf(ctx.Output, "MPR Format: v%d\n", pv.FormatVersion)
 
 	// Show module count
-	modules, err := e.backend.ListModules()
+	modules, err := ctx.Backend.ListModules()
 	if err == nil {
 		fmt.Fprintf(ctx.Output, "Modules: %d\n", len(modules))
 	}

--- a/mdl/executor/executor_dispatch.go
+++ b/mdl/executor/executor_dispatch.go
@@ -18,9 +18,9 @@ func (e *Executor) executeInner(ctx context.Context, stmt ast.Statement) error {
 
 // syncBack copies mutated ExecContext fields back to the Executor so that
 // the next newExecContext call picks up handler-side state changes.
-// This replaces the scattered ctx.executor.field = ctx.Field write-backs
-// that previously lived inside individual handlers.
 func (e *Executor) syncBack(ctx *ExecContext) {
+	e.backend = ctx.Backend
+	e.mprPath = ctx.MprPath
 	e.cache = ctx.Cache
 	e.catalog = ctx.Catalog
 	e.settings = ctx.Settings
@@ -32,20 +32,24 @@ func (e *Executor) syncBack(ctx *ExecContext) {
 // newExecContext builds an ExecContext from the current Executor state.
 func (e *Executor) newExecContext(ctx context.Context) *ExecContext {
 	return &ExecContext{
-		Context:       ctx,
-		Backend:       e.backend,
-		Output:        e.output,
-		Format:        e.format,
-		Quiet:         e.quiet,
-		Logger:        e.logger,
-		Fragments:     e.fragments,
-		Catalog:       e.catalog,
-		Cache:         e.cache,
-		MprPath:       e.mprPath,
-		SqlMgr:        e.sqlMgr,
-		ThemeRegistry: e.themeRegistry,
-		Settings:      e.settings,
-		executor:      e,
+		Context:          ctx,
+		Backend:          e.backend,
+		Output:           e.output,
+		Format:           e.format,
+		Quiet:            e.quiet,
+		Logger:           e.logger,
+		Fragments:        e.fragments,
+		Catalog:          e.catalog,
+		Cache:            e.cache,
+		MprPath:          e.mprPath,
+		SqlMgr:           e.sqlMgr,
+		ThemeRegistry:    e.themeRegistry,
+		Settings:         e.settings,
+		BackendFactory:   e.backendFactory,
+		OutputGuard:      e.guard,
+		ExecuteFn:        e.Execute,
+		ExecuteProgramFn: e.ExecuteProgram,
+		FinalizeFn:       e.finalizeProgramExecution,
 	}
 }
 

--- a/mdl/executor/executor_dispatch.go
+++ b/mdl/executor/executor_dispatch.go
@@ -11,7 +11,22 @@ import (
 // executeInner dispatches a statement to its registered handler.
 func (e *Executor) executeInner(ctx context.Context, stmt ast.Statement) error {
 	ectx := e.newExecContext(ctx)
-	return e.registry.Dispatch(ectx, stmt)
+	err := e.registry.Dispatch(ectx, stmt)
+	e.syncBack(ectx)
+	return err
+}
+
+// syncBack copies mutated ExecContext fields back to the Executor so that
+// the next newExecContext call picks up handler-side state changes.
+// This replaces the scattered ctx.executor.field = ctx.Field write-backs
+// that previously lived inside individual handlers.
+func (e *Executor) syncBack(ctx *ExecContext) {
+	e.cache = ctx.Cache
+	e.catalog = ctx.Catalog
+	e.settings = ctx.Settings
+	e.fragments = ctx.Fragments
+	e.sqlMgr = ctx.SqlMgr
+	e.themeRegistry = ctx.ThemeRegistry
 }
 
 // newExecContext builds an ExecContext from the current Executor state.

--- a/mdl/executor/executor_dispatch.go
+++ b/mdl/executor/executor_dispatch.go
@@ -12,7 +12,13 @@ import (
 func (e *Executor) executeInner(ctx context.Context, stmt ast.Statement) error {
 	ectx := e.newExecContext(ctx)
 	err := e.registry.Dispatch(ectx, stmt)
-	e.syncBack(ectx)
+	// Only sync back when the context has not been cancelled. Execute() runs
+	// executeInner in a goroutine with a wall-clock timeout; if the timeout
+	// fires, the goroutine keeps running but Execute() has already returned.
+	// Syncing stale state back at that point would race with subsequent calls.
+	if ctx.Err() == nil {
+		e.syncBack(ectx)
+	}
 	return err
 }
 
@@ -22,7 +28,7 @@ func (e *Executor) executeInner(ctx context.Context, stmt ast.Statement) error {
 // Fields intentionally NOT synced back (read-only from handler perspective):
 //   - Output, Format, Quiet, Logger — set once at Executor construction
 //   - BackendFactory — set once at Executor construction
-//   - OutputGuard — temporary swaps are always restored within the same handler
+//   - OutputGuard — removed; writeDescribeJSON captures via Output swap only
 //   - ExecuteFn, ExecuteProgramFn, FinalizeFn — bound to Executor methods, immutable
 func (e *Executor) syncBack(ctx *ExecContext) {
 	e.backend = ctx.Backend
@@ -52,7 +58,6 @@ func (e *Executor) newExecContext(ctx context.Context) *ExecContext {
 		ThemeRegistry:    e.themeRegistry,
 		Settings:         e.settings,
 		BackendFactory:   e.backendFactory,
-		OutputGuard:      e.guard,
 		ExecuteFn:        e.Execute,
 		ExecuteProgramFn: e.ExecuteProgram,
 		FinalizeFn:       e.finalizeProgramExecution,

--- a/mdl/executor/executor_dispatch.go
+++ b/mdl/executor/executor_dispatch.go
@@ -18,6 +18,12 @@ func (e *Executor) executeInner(ctx context.Context, stmt ast.Statement) error {
 
 // syncBack copies mutated ExecContext fields back to the Executor so that
 // the next newExecContext call picks up handler-side state changes.
+//
+// Fields intentionally NOT synced back (read-only from handler perspective):
+//   - Output, Format, Quiet, Logger — set once at Executor construction
+//   - BackendFactory — set once at Executor construction
+//   - OutputGuard — temporary swaps are always restored within the same handler
+//   - ExecuteFn, ExecuteProgramFn, FinalizeFn — bound to Executor methods, immutable
 func (e *Executor) syncBack(ctx *ExecContext) {
 	e.backend = ctx.Backend
 	e.mprPath = ctx.MprPath

--- a/mdl/executor/format.go
+++ b/mdl/executor/format.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"strings"
 )
 
@@ -115,32 +114,25 @@ func writeResultJSON(ctx *ExecContext, r *TableResult) error {
 // In table/text mode it calls fn directly. In JSON mode it captures fn's output
 // and wraps it as {"name": ..., "type": ..., "mdl": ...}.
 func writeDescribeJSON(ctx *ExecContext, name, objectType string, fn func() error) error {
-	e := ctx.executor
 	if ctx.Format != FormatJSON {
 		return fn()
 	}
 
 	// Capture the text output from fn.
-	// TODO: Once all handlers write to ctx.Output exclusively, the e.output/e.guard
-	// swap can be removed. Currently needed because some closures still write to e.output.
 	var buf bytes.Buffer
 	origOutput := ctx.Output
 	ctx.Output = &buf
 
-	// Swap executor output/guard only when a backing Executor exists.
-	var origEOutput io.Writer
+	// Disable line guard during capture so the captured text isn't truncated.
 	var origGuard *outputGuard
-	if e != nil {
-		origEOutput = e.output
-		origGuard = e.guard
-		e.output = &buf // sync executor output for closures that write to e.output
-		e.guard = nil   // disable line guard for capture
+	if ctx.OutputGuard != nil {
+		origGuard = ctx.OutputGuard
+		ctx.OutputGuard = nil
 	}
 	err := fn()
 	ctx.Output = origOutput
-	if e != nil {
-		e.output = origEOutput
-		e.guard = origGuard
+	if origGuard != nil {
+		ctx.OutputGuard = origGuard
 	}
 	if err != nil {
 		return err
@@ -162,10 +154,6 @@ func writeDescribeJSON(ctx *ExecContext, name, objectType string, fn func() erro
 
 func (e *Executor) writeResult(r *TableResult) error {
 	return writeResult(e.newExecContext(context.Background()), r)
-}
-
-func (e *Executor) writeDescribeJSON(name, objectType string, fn func() error) error {
-	return writeDescribeJSON(e.newExecContext(context.Background()), name, objectType, fn)
 }
 
 // formatCellValue formats a value for table cell display.

--- a/mdl/executor/format.go
+++ b/mdl/executor/format.go
@@ -123,17 +123,8 @@ func writeDescribeJSON(ctx *ExecContext, name, objectType string, fn func() erro
 	origOutput := ctx.Output
 	ctx.Output = &buf
 
-	// Disable line guard during capture so the captured text isn't truncated.
-	var origGuard *outputGuard
-	if ctx.OutputGuard != nil {
-		origGuard = ctx.OutputGuard
-		ctx.OutputGuard = nil
-	}
 	err := fn()
 	ctx.Output = origOutput
-	if origGuard != nil {
-		ctx.OutputGuard = origGuard
-	}
 	if err != nil {
 		return err
 	}

--- a/mdl/executor/format_test.go
+++ b/mdl/executor/format_test.go
@@ -112,10 +112,13 @@ func TestWriteResultJSONEmpty(t *testing.T) {
 
 func TestWriteDescribeJSON(t *testing.T) {
 	var buf bytes.Buffer
-	e := &Executor{output: &buf, format: FormatJSON}
+	ctx := &ExecContext{
+		Output: &buf,
+		Format: FormatJSON,
+	}
 
-	err := e.writeDescribeJSON("Sales.Customer", "entity", func() error {
-		_, err := e.output.Write([]byte("create entity Sales.Customer;\n"))
+	err := writeDescribeJSON(ctx, "Sales.Customer", "entity", func() error {
+		_, err := ctx.Output.Write([]byte("create entity Sales.Customer;\n"))
 		return err
 	})
 	if err != nil {
@@ -140,10 +143,13 @@ func TestWriteDescribeJSON(t *testing.T) {
 
 func TestWriteDescribeJSONPassthrough(t *testing.T) {
 	var buf bytes.Buffer
-	e := &Executor{output: &buf} // format is default (table)
+	ctx := &ExecContext{
+		Output: &buf,
+		Format: FormatTable,
+	}
 
-	err := e.writeDescribeJSON("Sales.Customer", "entity", func() error {
-		_, err := e.output.Write([]byte("create entity Sales.Customer;\n"))
+	err := writeDescribeJSON(ctx, "Sales.Customer", "entity", func() error {
+		_, err := ctx.Output.Write([]byte("create entity Sales.Customer;\n"))
 		return err
 	})
 	if err != nil {

--- a/mdl/executor/hierarchy.go
+++ b/mdl/executor/hierarchy.go
@@ -133,9 +133,6 @@ func getHierarchy(ctx *ExecContext) (*ContainerHierarchy, error) {
 	}
 	if ctx.Cache == nil {
 		ctx.Cache = &executorCache{}
-		if ctx.executor != nil {
-			ctx.executor.cache = ctx.Cache
-		}
 	}
 	if ctx.Cache.hierarchy != nil {
 		return ctx.Cache.hierarchy, nil

--- a/mdl/executor/hierarchy.go
+++ b/mdl/executor/hierarchy.go
@@ -3,7 +3,6 @@
 package executor
 
 import (
-	"context"
 	"strings"
 
 	"github.com/mendixlabs/mxcli/mdl/backend"
@@ -161,10 +160,4 @@ func invalidateDomainModelsCache(ctx *ExecContext) {
 	}
 }
 
-// ----------------------------------------------------------------------------
-// Executor method wrappers (for callers in unmigrated files)
-// ----------------------------------------------------------------------------
 
-func (e *Executor) getHierarchy() (*ContainerHierarchy, error) {
-	return getHierarchy(e.newExecContext(context.Background()))
-}


### PR DESCRIPTION
## Summary

Removes the `executor *Executor` back-pointer from `ExecContext`, replacing it with explicit fields and a centralized sync-back mechanism.

## Why

`ExecContext` carries per-statement state through handler functions, but it held a back-pointer to the parent `Executor` — creating a bidirectional dependency. Handlers used `ctx.executor` to:

1. **Sync state back** (cache, catalog, settings, fragments, themeRegistry) so the next statement dispatch would pick up mutations
2. **Call tracking methods** (`trackModifiedDomainModel`, `trackCreatedPage`, etc.) that lived on Executor
3. **Access lifecycle operations** (connect/disconnect, dispatch sub-statements, finalize security reconciliation)
4. **Swap output writers** for JSON capture

This coupling meant every handler implicitly depended on the full Executor, even when it only needed one or two fields. It also made it impossible to construct an `ExecContext` in tests without creating a full Executor.

## Approach

**Commit 1 — Centralize sync-back, lift tracking methods (16 sites)**
- Introduce `syncBack()` on Executor, called after each statement dispatch, replacing scattered inline sync-backs across 10+ handler files
- Move `trackModifiedDomainModel`, `trackCreated*`, `getCreated*`, `ensureCache`, `EnsureSqlMgr`, and `Reader` from Executor to ExecContext methods

**Commit 2 — Replace back-pointer with explicit fields (10 sites)**
- Add `BackendFactory`, `OutputGuard`, `ExecuteFn`, `ExecuteProgramFn`, `FinalizeFn` to ExecContext
- Rewrite `executor_connect.go` (connect/disconnect/reconnect/status) to use ExecContext fields directly
- Rewrite `format.go` output capture, `cmd_misc.go` script execution, `cmd_sql.go` generated MDL dispatch
- Remove the `executor` field — zero `ctx.executor` references remain

**Commit 3 — Hardening**
- Shallow-copy ExecContext for background catalog goroutine to prevent races with syncBack
- Add nil guards on `ExecuteFn`/`ExecuteProgramFn`
- Document syncBack field asymmetry (which fields are intentionally not synced)
- Remove dead Executor receiver methods

## Testing

All existing tests pass. Test files updated to construct `ExecContext` directly without Executor where possible.