### PR TITLE
refactor: extract CatalogDB interface for WASM portability

### DIFF
--- a/mdl/catalog/builder.go
+++ b/mdl/catalog/builder.go
@@ -3,7 +3,6 @@
 package catalog
 
 import (
-	"database/sql"
 	"fmt"
 	"strings"
 	"time"
@@ -79,7 +78,7 @@ type Builder struct {
 	snapshot     *Snapshot
 	progress     ProgressFunc
 	hierarchy    *hierarchy
-	tx           *sql.Tx // Transaction for batched inserts
+	tx           CatalogTx // Transaction for batched inserts
 	fullMode     bool    // If true, do full parsing (activities/widgets)
 	sourceMode   bool    // If true, build source FTS table (implies full)
 	describeFunc DescribeFunc

--- a/mdl/catalog/catalog.go
+++ b/mdl/catalog/catalog.go
@@ -8,13 +8,11 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	_ "modernc.org/sqlite"
 )
 
 // Catalog provides SQL querying over Mendix project metadata.
 type Catalog struct {
-	db            *sql.DB
+	db            CatalogDB
 	projectID     string
 	projectName   string
 	mendixVersion string
@@ -58,17 +56,15 @@ type ProgressFunc func(table string, count int)
 
 // New creates a new catalog with an in-memory SQLite database.
 func New() (*Catalog, error) {
-	db, err := sql.Open("sqlite", ":memory:")
+	db, err := NewSqliteCatalogDB()
 	if err != nil {
 		return nil, fmt.Errorf("failed to open in-memory database: %w", err)
 	}
+	return NewFromDB(db)
+}
 
-	// Enable foreign keys
-	if _, err := db.Exec("PRAGMA foreign_keys = ON"); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("failed to enable foreign keys: %w", err)
-	}
-
+// NewFromDB creates a catalog from an existing CatalogDB.
+func NewFromDB(db CatalogDB) (*Catalog, error) {
 	c := &Catalog{
 		db:        db,
 		projectID: "default",
@@ -193,8 +189,8 @@ func (c *Catalog) Query(sqlQuery string) (*QueryResult, error) {
 	return result, rows.Err()
 }
 
-// DB returns the underlying database connection for direct access.
-func (c *Catalog) DB() *sql.DB {
+// CatalogDB returns the underlying database abstraction.
+func (c *Catalog) CatalogDB() CatalogDB {
 	return c.db
 }
 
@@ -263,15 +259,9 @@ type CacheInfo struct {
 
 // NewFromFile opens a catalog from a persisted SQLite file.
 func NewFromFile(path string) (*Catalog, error) {
-	db, err := sql.Open("sqlite", path)
+	db, err := NewSqliteCatalogDBFromFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open catalog file: %w", err)
-	}
-
-	// Enable foreign keys
-	if _, err := db.Exec("PRAGMA foreign_keys = ON"); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("failed to enable foreign keys: %w", err)
 	}
 
 	c := &Catalog{
@@ -286,7 +276,14 @@ func NewFromFile(path string) (*Catalog, error) {
 
 // SaveToFile saves the catalog to a SQLite file.
 // This copies the in-memory database to a file for persistence.
+// Requires the underlying CatalogDB to be a *SqliteCatalogDB.
 func (c *Catalog) SaveToFile(path string) error {
+	sdb, ok := c.db.(*SqliteCatalogDB)
+	if !ok {
+		return fmt.Errorf("SaveToFile requires a SQLite-backed catalog")
+	}
+	rawDB := sdb.RawDB()
+
 	// Open destination file database
 	destDB, err := sql.Open("sqlite", path)
 	if err != nil {
@@ -296,17 +293,17 @@ func (c *Catalog) SaveToFile(path string) error {
 
 	// Use SQLite backup API via VACUUM INTO (SQLite 3.27+)
 	// Fall back to manual copy if not available
-	_, err = c.db.Exec(fmt.Sprintf("VACUUM INTO '%s'", path))
+	_, err = rawDB.Exec(fmt.Sprintf("VACUUM INTO '%s'", path))
 	if err != nil {
 		// Fall back: export and import
-		return c.saveToFileManual(path)
+		return c.saveToFileManual(path, rawDB)
 	}
 
 	return nil
 }
 
 // saveToFileManual saves by dumping and restoring (fallback method).
-func (c *Catalog) saveToFileManual(path string) error {
+func (c *Catalog) saveToFileManual(path string, rawDB *sql.DB) error {
 	// Open destination
 	destDB, err := sql.Open("sqlite", path)
 	if err != nil {
@@ -315,7 +312,7 @@ func (c *Catalog) saveToFileManual(path string) error {
 	defer destDB.Close()
 
 	// Get list of tables
-	rows, err := c.db.Query("SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+	rows, err := rawDB.Query("SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
 	if err != nil {
 		return err
 	}
@@ -339,7 +336,7 @@ func (c *Catalog) saveToFileManual(path string) error {
 		}
 
 		// Copy data
-		srcRows, err := c.db.Query(fmt.Sprintf("SELECT * FROM %s", t.name))
+		srcRows, err := rawDB.Query(fmt.Sprintf("SELECT * FROM %s", t.name))
 		if err != nil {
 			return err
 		}
@@ -377,7 +374,7 @@ func (c *Catalog) saveToFileManual(path string) error {
 	}
 
 	// Copy views
-	rows, err = c.db.Query("SELECT sql FROM sqlite_master WHERE type='view'")
+	rows, err = rawDB.Query("SELECT sql FROM sqlite_master WHERE type='view'")
 	if err != nil {
 		return err
 	}
@@ -394,7 +391,7 @@ func (c *Catalog) saveToFileManual(path string) error {
 	rows.Close()
 
 	// Copy indexes
-	rows, err = c.db.Query("SELECT sql FROM sqlite_master WHERE type='index' AND sql IS NOT NULL")
+	rows, err = rawDB.Query("SELECT sql FROM sqlite_master WHERE type='index' AND sql IS NOT NULL")
 	if err != nil {
 		return err
 	}

--- a/mdl/catalog/catalog_test.go
+++ b/mdl/catalog/catalog_test.go
@@ -124,7 +124,7 @@ func TestQueryWithData(t *testing.T) {
 	defer cat.Close()
 
 	// Insert test data
-	_, err = cat.DB().Exec(
+	_, err = cat.CatalogDB().Exec(
 		"INSERT INTO modules (Id, Name, QualifiedName, ModuleName) VALUES (?, ?, ?, ?)",
 		"mod-1", "TestModule", "TestModule", "TestModule",
 	)
@@ -280,7 +280,7 @@ func TestSaveAndLoadFromFile(t *testing.T) {
 	}
 
 	cat.SetProject("proj-1", "TestApp", "10.0.0")
-	_, err = cat.DB().Exec(
+	_, err = cat.CatalogDB().Exec(
 		"INSERT INTO modules (Id, Name, QualifiedName, ModuleName) VALUES (?, ?, ?, ?)",
 		"mod-1", "MyModule", "MyModule", "MyModule",
 	)
@@ -359,7 +359,7 @@ func TestRoleMappingsTable(t *testing.T) {
 	}
 
 	for _, m := range mappings {
-		_, err := cat.DB().Exec(
+		_, err := cat.CatalogDB().Exec(
 			"INSERT INTO role_mappings (UserRoleName, ModuleRoleName, ModuleName) VALUES (?, ?, ?)",
 			m.userRole, m.moduleRole, m.module,
 		)

--- a/mdl/catalog/catalogdb.go
+++ b/mdl/catalog/catalogdb.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import "database/sql"
+
+// CatalogDB abstracts the database layer used by Catalog and LintContext.
+// The primary implementation wraps modernc.org/sqlite for native builds;
+// a js/wasm build will supply a host-backed implementation.
+type CatalogDB interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+	Exec(query string, args ...any) (sql.Result, error)
+	Begin() (CatalogTx, error)
+	Close() error
+}
+
+// CatalogTx abstracts a database transaction. Builder uses this for bulk
+// inserts with prepared statements.
+type CatalogTx interface {
+	Prepare(query string) (*sql.Stmt, error)
+	Exec(query string, args ...any) (sql.Result, error)
+	QueryRow(query string, args ...any) *sql.Row
+	Commit() error
+	Rollback() error
+}

--- a/mdl/catalog/catalogdb_sqlite.go
+++ b/mdl/catalog/catalogdb_sqlite.go
@@ -66,3 +66,9 @@ func (s *SqliteCatalogDB) Close() error {
 func (s *SqliteCatalogDB) RawDB() *sql.DB {
 	return s.db
 }
+
+// WrapSqlDB wraps an existing *sql.DB as a CatalogDB.
+// Used by tests that create their own in-memory databases.
+func WrapSqlDB(db *sql.DB) *SqliteCatalogDB {
+	return &SqliteCatalogDB{db: db}
+}

--- a/mdl/catalog/catalogdb_sqlite.go
+++ b/mdl/catalog/catalogdb_sqlite.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !js
+
+package catalog
+
+import (
+	"database/sql"
+
+	_ "modernc.org/sqlite"
+)
+
+// SqliteCatalogDB wraps *sql.DB from modernc.org/sqlite.
+type SqliteCatalogDB struct {
+	db *sql.DB
+}
+
+// NewSqliteCatalogDB opens an in-memory SQLite database.
+func NewSqliteCatalogDB() (*SqliteCatalogDB, error) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		return nil, err
+	}
+	if _, err := db.Exec("PRAGMA foreign_keys = ON"); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return &SqliteCatalogDB{db: db}, nil
+}
+
+// NewSqliteCatalogDBFromFile opens a file-based SQLite database.
+func NewSqliteCatalogDBFromFile(path string) (*SqliteCatalogDB, error) {
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := db.Exec("PRAGMA foreign_keys = ON"); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return &SqliteCatalogDB{db: db}, nil
+}
+
+func (s *SqliteCatalogDB) Query(query string, args ...any) (*sql.Rows, error) {
+	return s.db.Query(query, args...)
+}
+
+func (s *SqliteCatalogDB) QueryRow(query string, args ...any) *sql.Row {
+	return s.db.QueryRow(query, args...)
+}
+
+func (s *SqliteCatalogDB) Exec(query string, args ...any) (sql.Result, error) {
+	return s.db.Exec(query, args...)
+}
+
+func (s *SqliteCatalogDB) Begin() (CatalogTx, error) {
+	return s.db.Begin()
+}
+
+func (s *SqliteCatalogDB) Close() error {
+	return s.db.Close()
+}
+
+// RawDB returns the underlying *sql.DB. Used only for SQLite-specific
+// operations like VACUUM INTO in SaveToFile.
+func (s *SqliteCatalogDB) RawDB() *sql.DB {
+	return s.db
+}

--- a/mdl/catalog/catalogdb_test.go
+++ b/mdl/catalog/catalogdb_test.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !js
+
+package catalog
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// TestCatalogDBContract verifies that SqliteCatalogDB satisfies the CatalogDB
+// interface contract: basic CRUD, transactions, and cleanup.
+func TestCatalogDBContract(t *testing.T) {
+	db, err := NewSqliteCatalogDB()
+	if err != nil {
+		t.Fatalf("NewSqliteCatalogDB: %v", err)
+	}
+	defer db.Close()
+
+	// Exec — create a table.
+	_, err = db.Exec("CREATE TABLE test_contract (id INTEGER PRIMARY KEY, name TEXT)")
+	if err != nil {
+		t.Fatalf("Exec CREATE TABLE: %v", err)
+	}
+
+	// Exec — insert a row.
+	res, err := db.Exec("INSERT INTO test_contract (id, name) VALUES (?, ?)", 1, "alpha")
+	if err != nil {
+		t.Fatalf("Exec INSERT: %v", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		t.Fatalf("RowsAffected: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 row affected, got %d", n)
+	}
+
+	// QueryRow — read it back.
+	var name string
+	row := db.QueryRow("SELECT name FROM test_contract WHERE id = ?", 1)
+	if err := row.Scan(&name); err != nil {
+		t.Fatalf("QueryRow Scan: %v", err)
+	}
+	if name != "alpha" {
+		t.Errorf("expected alpha, got %q", name)
+	}
+
+	// Query — list rows.
+	rows, err := db.Query("SELECT id, name FROM test_contract ORDER BY id")
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	defer rows.Close()
+	count := 0
+	for rows.Next() {
+		var id int
+		var n string
+		if err := rows.Scan(&id, &n); err != nil {
+			t.Fatalf("rows.Scan: %v", err)
+		}
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 row, got %d", count)
+	}
+}
+
+func TestCatalogTxContract(t *testing.T) {
+	db, err := NewSqliteCatalogDB()
+	if err != nil {
+		t.Fatalf("NewSqliteCatalogDB: %v", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec("CREATE TABLE test_tx (id INTEGER PRIMARY KEY, val TEXT)")
+	if err != nil {
+		t.Fatalf("Exec CREATE TABLE: %v", err)
+	}
+
+	// Begin + Prepare + Exec + Commit.
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	stmt, err := tx.Prepare("INSERT INTO test_tx (id, val) VALUES (?, ?)")
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	for i := 1; i <= 3; i++ {
+		if _, err := stmt.Exec(i, "row"); err != nil {
+			t.Fatalf("stmt.Exec(%d): %v", i, err)
+		}
+	}
+	stmt.Close()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// Verify rows persisted.
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM test_tx").Scan(&count); err != nil {
+		t.Fatalf("QueryRow after commit: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 rows after commit, got %d", count)
+	}
+
+	// Begin + Rollback — rows should not persist.
+	tx2, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin (rollback): %v", err)
+	}
+	if _, err := tx2.Exec("INSERT INTO test_tx (id, val) VALUES (4, 'gone')"); err != nil {
+		t.Fatalf("Exec in rollback tx: %v", err)
+	}
+	if err := tx2.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+
+	if err := db.QueryRow("SELECT COUNT(*) FROM test_tx").Scan(&count); err != nil {
+		t.Fatalf("QueryRow after rollback: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 rows after rollback, got %d", count)
+	}
+}
+
+// TestInterfaceSatisfaction verifies compile-time interface compliance.
+func TestInterfaceSatisfaction(t *testing.T) {
+	var _ CatalogDB = (*SqliteCatalogDB)(nil)
+	var _ CatalogTx = (*sql.Tx)(nil)
+}

--- a/mdl/linter/context.go
+++ b/mdl/linter/context.go
@@ -13,7 +13,7 @@ import (
 // LintContext wraps a catalog and provides rule-friendly APIs.
 type LintContext struct {
 	catalog  *catalog.Catalog
-	db       *sql.DB
+	db       catalog.CatalogDB
 	excluded map[string]bool
 	reader   *mpr.Reader
 }
@@ -32,14 +32,14 @@ func (ctx *LintContext) Reader() *mpr.Reader {
 func NewLintContext(cat *catalog.Catalog) *LintContext {
 	return &LintContext{
 		catalog:  cat,
-		db:       cat.DB(),
+		db:       cat.CatalogDB(),
 		excluded: make(map[string]bool),
 	}
 }
 
-// NewLintContextFromDB creates a new LintContext from a raw database connection.
+// NewLintContextFromDB creates a new LintContext from a CatalogDB.
 // Used in tests to provide an in-memory database with test data.
-func NewLintContextFromDB(db *sql.DB) *LintContext {
+func NewLintContextFromDB(db catalog.CatalogDB) *LintContext {
 	return &LintContext{
 		db:       db,
 		excluded: make(map[string]bool),
@@ -64,8 +64,8 @@ func (ctx *LintContext) Catalog() *catalog.Catalog {
 	return ctx.catalog
 }
 
-// DB returns the underlying database connection for advanced queries.
-func (ctx *LintContext) DB() *sql.DB {
+// CatalogDB returns the underlying database abstraction for advanced queries.
+func (ctx *LintContext) CatalogDB() catalog.CatalogDB {
 	return ctx.db
 }
 

--- a/mdl/linter/rules/empty_test.go
+++ b/mdl/linter/rules/empty_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/mendixlabs/mxcli/mdl/catalog"
 	"github.com/mendixlabs/mxcli/mdl/linter"
 
 	_ "modernc.org/sqlite"
@@ -13,7 +14,7 @@ import (
 
 // setupMicroflowsDB creates an in-memory SQLite database with the microflows and modules tables.
 // Each row is [Id, Name, QualifiedName, ModuleName, Folder, MicroflowType, Description, ReturnType, ParameterCount, ActivityCount, Complexity].
-func setupMicroflowsDB(t *testing.T, rows [][]any) *sql.DB {
+func setupMicroflowsDB(t *testing.T, rows [][]any) catalog.CatalogDB {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
@@ -47,7 +48,7 @@ func setupMicroflowsDB(t *testing.T, rows [][]any) *sql.DB {
 		}
 	}
 
-	return db
+	return catalog.WrapSqlDB(db)
 }
 
 func TestEmptyMicroflowRule_NoViolations(t *testing.T) {

--- a/mdl/linter/rules/helpers_test.go
+++ b/mdl/linter/rules/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/mendixlabs/mxcli/mdl/catalog"
 	"github.com/mendixlabs/mxcli/mdl/linter"
 
 	_ "modernc.org/sqlite"
@@ -22,7 +23,7 @@ func testMicroflow() linter.Microflow {
 }
 
 // setupEntitiesDB creates an in-memory SQLite database with entities and modules tables.
-func setupEntitiesDB(t *testing.T, entities [][]any) *sql.DB {
+func setupEntitiesDB(t *testing.T, entities [][]any) catalog.CatalogDB {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
@@ -56,5 +57,5 @@ func setupEntitiesDB(t *testing.T, entities [][]any) *sql.DB {
 		}
 	}
 
-	return db
+	return catalog.WrapSqlDB(db)
 }

--- a/mdl/linter/rules/missing_translations.go
+++ b/mdl/linter/rules/missing_translations.go
@@ -29,7 +29,7 @@ func (r *MissingTranslationsRule) Description() string {
 // Check runs the missing translations check.
 // Requires REFRESH CATALOG FULL to populate the strings table.
 func (r *MissingTranslationsRule) Check(ctx *linter.LintContext) []linter.Violation {
-	db := ctx.DB()
+	db := ctx.CatalogDB()
 	if db == nil {
 		return nil
 	}

--- a/mdl/linter/rules/missing_translations_test.go
+++ b/mdl/linter/rules/missing_translations_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/mendixlabs/mxcli/mdl/catalog"
 	"github.com/mendixlabs/mxcli/mdl/linter"
 
 	_ "modernc.org/sqlite"
@@ -14,7 +15,7 @@ import (
 // setupTranslationsDB creates an in-memory SQLite database with the strings FTS5 table
 // and inserts test data. Rows are [QualifiedName, ObjectType, StringValue, StringContext, Language, ModuleName].
 // ElementId is auto-generated from QualifiedName+StringContext for simplicity.
-func setupTranslationsDB(t *testing.T, rows [][]string) *sql.DB {
+func setupTranslationsDB(t *testing.T, rows [][]string) catalog.CatalogDB {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
@@ -46,7 +47,7 @@ func setupTranslationsDB(t *testing.T, rows [][]string) *sql.DB {
 		}
 	}
 
-	return db
+	return catalog.WrapSqlDB(db)
 }
 
 func TestMissingTranslations_NoViolationsWhenComplete(t *testing.T) {


### PR DESCRIPTION
## Why

`mdl/catalog/` and `mdl/linter/` depend directly on `*sql.DB` and `modernc.org/sqlite`. To compile mxcli as a WASM module (for embedding in Studio Pro's Maia client), the catalog layer needs to delegate SQL operations to the host process instead. This PR introduces an interface boundary so a future `JsCatalogDB` implementation can swap in without touching any consumer code.

> **Stacked on #274** — merge #274 first, then rebase this PR.

## Changes

- **`catalogdb.go`** — `CatalogDB` interface (Query, QueryRow, Exec, Begin, Close) + `CatalogTx` interface (Prepare, Exec, QueryRow, Commit, Rollback)
- **`catalogdb_sqlite.go`** — `SqliteCatalogDB` wrapping `*sql.DB` (`//go:build !js`), with `RawDB()` escape hatch and `WrapSqlDB()` test helper
- **`catalog.go`** — `db *sql.DB` → `CatalogDB`, `DB()` → `CatalogDB()`, `New()` delegates to `NewSqliteCatalogDB()`, `NewFromDB()` constructor added, `SaveToFile` uses type assertion
- **`builder.go`** — `tx *sql.Tx` → `CatalogTx`
- **`linter/context.go`** — `db *sql.DB` → `catalog.CatalogDB`, `DB()` → `CatalogDB()`
- **`rules/missing_translations.go`** — `ctx.DB()` → `ctx.CatalogDB()`
- **Test files** — wrap `*sql.DB` via `catalog.WrapSqlDB()`, contract tests for both interfaces, compile-time interface satisfaction checks

## Design decisions

- Interface returns `*sql.Rows` / `*sql.Row` to avoid rewriting 18 linter scan sites
- `CatalogTx.Prepare()` returns `*sql.Stmt` — keeps Builder's bulk insert pattern unchanged
- `SaveToFile` stays SQLite-specific via type assertion (uses `VACUUM INTO`)
- `JsCatalogDB` stub deferred to follow-up PR — needs WASM bridge design