### PR TITLE
fix: create OpenApiTest module before use in openapi-import doctype test

### DIFF
--- a/mdl-examples/doctype-tests/20-openapi-import-examples.mdl
+++ b/mdl-examples/doctype-tests/20-openapi-import-examples.mdl
@@ -15,19 +15,21 @@ describe contract operation from openapi 'https://petstore3.swagger.io/api/v3/op
 -- CREATE REST CLIENT with OpenAPI source
 -- ============================================================================
 
+create module OpenApiTest;
+
 -- Minimal: spec drives everything (operations, BaseUrl, auth)
-create or modify rest client ClaudeKhodeLab.PetStoreMinimal (
+create or modify rest client OpenApiTest.PetStoreMinimal (
   OpenAPI: 'https://petstore3.swagger.io/api/v3/openapi.json'
 );
 
 -- With BaseUrl override: replaces servers[0].url from the spec
-create or modify rest client ClaudeKhodeLab.PetStoreV4 (
+create or modify rest client OpenApiTest.PetStoreV4 (
   OpenAPI: 'https://petstore3.swagger.io/api/v3/openapi.json',
   BaseUrl: 'https://petstore3.swagger.io/api/v4'
 );
 
 -- Verify the created service is visible
-show rest clients in ClaudeKhodeLab;
+show rest clients in OpenApiTest;
 
 -- Describe the created service (roundtrip)
-describe rest client ClaudeKhodeLab.PetStoreMinimal;
+describe rest client OpenApiTest.PetStoreMinimal;


### PR DESCRIPTION
The test was referencing ClaudeKhodeLab which doesn't exist in the test project, causing "module not found" at CI time.