### PR TITLE
Document DataGrid2 column name derivation rules and TextTemplate read path

### DIFF
--- a/.claude/skills/mendix/alter-page.md
+++ b/.claude/skills/mendix/alter-page.md
@@ -150,6 +150,14 @@ REPLACE dgProducts.Description WITH {
 
 To discover column names, run `DESCRIBE PAGE Module.PageName` and look at the COLUMN names inside the DATAGRID.
 
+**Troubleshooting: column operation succeeds but does nothing**
+If an ALTER targeting a DataGrid column completes without error but makes no change, the column name used in the statement didn't match any column. The most common cause is a mismatch between what DESCRIBE shows and what ALTER resolves internally. Derivation rules:
+- Attribute-bound column → short attribute name (last segment after `.`): `Module.Entity.Description` → `Description`
+- Caption-only column → sanitized caption (non-alphanumeric replaced with `_`, leading/trailing `_` trimmed): `"Order Status"` → `Order_Status`
+- Caption with only special chars (e.g. `"---"`) → falls back to `col1`, `col2`, … (1-based index)
+
+If the column name you copied from DESCRIBE still doesn't work, check whether the column has an attribute binding — attribute names take priority over captions.
+
 ### ADD Variables - Add a Page Variable
 
 ```sql

--- a/.claude/skills/mendix/debug-bson.md
+++ b/.claude/skills/mendix/debug-bson.md
@@ -540,6 +540,28 @@ After fixing templates:
 2. Run `mx check app.mpr` - should return 0 errors
 3. Open in Studio Pro - widget should load without "Update widget" prompt
 
+### Reading TextTemplate in executor code
+
+Part 10 above covers writing `Forms$ClientTemplate`. The same structure applies when **reading** it in executor code (e.g. `cmd_alter_page.go`, `cmd_pages_describe_output.go`).
+
+The correct traversal is:
+```
+TextTemplate (Forms$ClientTemplate) → Template (Texts$Text) → Items[] → Translation { Text }
+```
+
+**Do not** read `Items` directly off the `TextTemplate` document — that skips the intermediate `Template` node and silently returns an empty slice. Always traverse one level deeper:
+
+```go
+// WRONG — Items is always empty
+items := dGetArrayElements(dGet(tmplDoc, "Items"))
+
+// CORRECT — traverse Template first
+template := dGetDoc(tmplDoc, "Template")
+items := dGetArrayElements(dGet(template, "Items"))
+```
+
+This applies to any executor function that reads column headers, button captions, or any other translatable text stored as `Forms$ClientTemplate`.
+
 ## Related Documentation
 
 - [BSON Mapping Specification](../../docs/05-mdl-specification/10-bson-mapping.md)


### PR DESCRIPTION
## Summary

Follow-up to #298. Documents two lessons surfaced by issue #116 so future contributors don't repeat the same mistakes.

- **`alter-page.md`** — adds a troubleshooting section under DataGrid Column Operations explaining the silent no-op symptom when column names don't match ALTER PAGE expectations, and documents all three derivation rules (attribute short name → `Description`; sanitized caption → `Order_Status`; all-special-char caption → `col{N}`)
- **`debug-bson.md`** — adds a "Reading TextTemplate in executor code" subsection to Part 10 documenting the correct `TextTemplate → Template → Items` traversal path, with wrong/correct Go examples. The missing `Template` level was the root cause of #116.

## Test plan

- [x] Docs-only change — no code modified
- [x] Spot-checked both files for accuracy against the fixed code in #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)