### PR TITLE
refactor: extract microflow anchor selection helpers

### DIFF
--- a/mdl/executor/cmd_microflows_builder_control.go
+++ b/mdl/executor/cmd_microflows_builder_control.go
@@ -125,10 +125,7 @@ func (fb *flowBuilder) addIfStatement(s *ast.IfStmt) model.ID {
 					// Destination: prefer the first statement's own @anchor(to: ...) if it
 					// has one; otherwise fall back to trueBranchAnchor.To.
 					flow := newHorizontalFlowWithCase(splitID, actID, "true")
-					applyUserAnchors(flow, trueBranchAnchor, trueBranchAnchor)
-					if thisAnchor != nil && thisAnchor.To != ast.AnchorSideUnset {
-						flow.DestinationConnectionIndex = int(thisAnchor.To)
-					}
+					applyUserAnchors(flow, trueBranchAnchor, branchDestinationAnchor(trueBranchAnchor, thisAnchor))
 					fb.flows = append(fb.flows, flow)
 				} else {
 					flow := newHorizontalFlow(lastThenID, actID)
@@ -178,10 +175,7 @@ func (fb *flowBuilder) addIfStatement(s *ast.IfStmt) model.ID {
 					// First statement in ELSE - connect from split going down (false path).
 					// Same compositional rule as the THEN branch.
 					flow := newDownwardFlowWithCase(splitID, actID, "false")
-					applyUserAnchors(flow, falseBranchAnchor, falseBranchAnchor)
-					if thisAnchor != nil && thisAnchor.To != ast.AnchorSideUnset {
-						flow.DestinationConnectionIndex = int(thisAnchor.To)
-					}
+					applyUserAnchors(flow, falseBranchAnchor, branchDestinationAnchor(falseBranchAnchor, thisAnchor))
 					fb.flows = append(fb.flows, flow)
 				} else {
 					flow := newHorizontalFlow(lastElseID, actID)
@@ -237,10 +231,7 @@ func (fb *flowBuilder) addIfStatement(s *ast.IfStmt) model.ID {
 				if lastThenID == "" {
 					// First statement in THEN - connect from split going down with "true" case
 					flow := newDownwardFlowWithCase(splitID, actID, "true")
-					applyUserAnchors(flow, trueBranchAnchor, trueBranchAnchor)
-					if thisAnchor != nil && thisAnchor.To != ast.AnchorSideUnset {
-						flow.DestinationConnectionIndex = int(thisAnchor.To)
-					}
+					applyUserAnchors(flow, trueBranchAnchor, branchDestinationAnchor(trueBranchAnchor, thisAnchor))
 					fb.flows = append(fb.flows, flow)
 				} else {
 					flow := newHorizontalFlow(lastThenID, actID)

--- a/mdl/executor/cmd_microflows_builder_flows.go
+++ b/mdl/executor/cmd_microflows_builder_flows.go
@@ -191,6 +191,20 @@ func applyUserAnchors(flow *microflows.SequenceFlow, origin *ast.FlowAnchors, de
 	}
 }
 
+func branchDestinationAnchor(branchAnchor, stmtAnchor *ast.FlowAnchors) *ast.FlowAnchors {
+	if stmtAnchor != nil && stmtAnchor.To != ast.AnchorSideUnset {
+		return stmtAnchor
+	}
+	return branchAnchor
+}
+
+func pendingFlowAnchors(previousAnchor, pendingAnchor, stmtAnchor *ast.FlowAnchors) (*ast.FlowAnchors, *ast.FlowAnchors) {
+	if pendingAnchor == nil {
+		return previousAnchor, stmtAnchor
+	}
+	return pendingAnchor, branchDestinationAnchor(pendingAnchor, stmtAnchor)
+}
+
 // lastStmtIsReturn reports whether execution of a body is guaranteed to terminate
 // (via RETURN or RAISE ERROR) on every path — i.e. control can never fall off the
 // end of the body into the parent flow.

--- a/mdl/executor/cmd_microflows_builder_graph.go
+++ b/mdl/executor/cmd_microflows_builder_graph.go
@@ -88,15 +88,8 @@ func (fb *flowBuilder) buildFlowGraph(stmts []ast.MicroflowStatement, returns *a
 			// both From (origin side on the split) and To (the side of the
 			// continuing activity), unless the incoming statement explicitly
 			// overrides its own To.
-			originAnchor := fb.previousStmtAnchor
-			destAnchor := stmtAnchor
-			if pendingFlowAnchor != nil {
-				originAnchor = pendingFlowAnchor
-				if destAnchor == nil || destAnchor.To == ast.AnchorSideUnset {
-					destAnchor = pendingFlowAnchor
-				}
-				pendingFlowAnchor = nil
-			}
+			originAnchor, destAnchor := pendingFlowAnchors(fb.previousStmtAnchor, pendingFlowAnchor, stmtAnchor)
+			pendingFlowAnchor = nil
 			applyUserAnchors(flow, originAnchor, destAnchor)
 			fb.flows = append(fb.flows, flow)
 			fb.previousStmtAnchor = stmtAnchor


### PR DESCRIPTION
Part of #332.

Closes #324.

## Summary

Extracts duplicated microflow builder anchor selection logic into two helpers. This is a no-behavior-change refactor intended to make follow-up anchor/handler fixes smaller and easier to review.

## Root cause

Several builder paths repeated the same precedence checks inline for pending anchors, branch anchors, and statement anchors.

## Refactor

- Add `branchDestinationAnchor`.
- Add `pendingFlowAnchors`.
- Route existing IF and graph construction call sites through the helpers.

## Behavior

No behavior change intended. Behavior-changing fixes remain in separate branches.

## Tests

No new behavior tests added because this only extracts existing logic. Existing tests cover the affected paths.

## Validation

- [x] `make build`
- [x] `make test`
- [x] `make lint-go`
- [x] `make test-integration`

## Agentic Code Testing

- [x] No user-facing syntax or behavior change.
- [x] Existing test suite covers the refactored builder paths.

## Test plan

- [x] Full test suite remains green after refactor.