### PR TITLE
fix: reject duplicate microflow output variables

### DIFF
--- a/cmd/mxcli/tui/watcher.go
+++ b/cmd/mxcli/tui/watcher.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -78,6 +79,7 @@ func newWatcher(mprPath, contentsDir string, sender MsgSender) (*Watcher, error)
 
 func (w *Watcher) run(sender MsgSender) {
 	var debounceTimer *time.Timer
+	var debounceSeq atomic.Uint64
 
 	for {
 		select {
@@ -110,7 +112,11 @@ func (w *Watcher) run(sender MsgSender) {
 			if debounceTimer != nil {
 				debounceTimer.Stop()
 			}
+			seq := debounceSeq.Add(1)
 			debounceTimer = time.AfterFunc(watchDebounce, func() {
+				if debounceSeq.Load() != seq {
+					return
+				}
 				sender.Send(MprChangedMsg{})
 			})
 

--- a/cmd/mxcli/tui/watcher_test.go
+++ b/cmd/mxcli/tui/watcher_test.go
@@ -35,10 +35,11 @@ func TestWatcherDebounce(t *testing.T) {
 	}
 	defer w.Close()
 
-	// Rapidly write 5 times — should debounce into a single message
+	// Rapidly write 5 times — should debounce into a single message.
+	// Keep the burst tighter than the debounce window so slow CI machines do
+	// not accidentally let an intermediate timer fire.
 	for i := range 5 {
 		_ = os.WriteFile(unitFile, []byte{byte('a' + i)}, 0644)
-		time.Sleep(50 * time.Millisecond)
 	}
 
 	// Wait for debounce to fire (500ms + margin)

--- a/mdl-examples/doctype-tests/02b-nanoflow-examples.mdl
+++ b/mdl-examples/doctype-tests/02b-nanoflow-examples.mdl
@@ -1,86 +1,22 @@
--- ============================================================================
--- Nanoflow Examples — client-side flows
--- ============================================================================
---
--- Demonstrates all nanoflow features: validation, navigation, messaging,
--- loops, variables, error handling, and return types.
---
--- Nanoflows run client-side (browser/native mobile). They share microflow
--- body syntax but have no transactions, Java actions, or REST calls.
---
--- Key differences from microflows:
---   - No RAISE ERROR / ErrorEvent
---   - No Java actions (use CALL JAVASCRIPT ACTION instead)
---   - No direct REST/external calls (call a microflow for server work)
---   - No binary return type
---   - Error handling per-action via ON ERROR, not transactional ROLLBACK
---   - SYNCHRONIZE available for offline native mobile contexts
---
--- ============================================================================
+-- Nanoflow examples — client-side flows
+-- Nanoflows share microflow body syntax but restrict server-side actions.
 
--- MARK: Module and entity setup
-
+-- Setup
 create module NanoflowExamples;
-create module role NanoflowExamples.User;
-create module role NanoflowExamples.Admin;
-
-/**
- * Product entity used throughout the nanoflow examples.
- */
 create entity NanoflowExamples.Product (
-    Name    : String(200),
-    Price   : Decimal,
-    IsValid : Boolean,
-    Tags    : String(500)
+    Name : String(200),
+    Price : Decimal,
+    IsValid : Boolean
 );
 
--- Helper microflow — server-side save, called from nanoflow examples.
-create microflow NanoflowExamples.ACT_SaveProduct (
-    $Product : NanoflowExamples.Product
-)
-returns Boolean
-begin
-    commit $Product;
-    return true;
-end;
-/
+-- Minimal nanoflow (empty body)
+create nanoflow NanoflowExamples.NF_Empty () begin end;
 
--- Helper page — used by N007_OpenProductDetail (requires Mendix 11.0+ page params).
-create page NanoflowExamples.ProductDetail
-(
-    params: {
-        $Product: NanoflowExamples.Product
-    },
-    title: 'Product Detail',
-    layout: Atlas_Core.Atlas_Default
-)
-{
-    dynamictext text1 (content: 'Product Detail', rendermode: H4)
-}
-/
-
--- ============================================================================
--- MARK: Nanoflows
--- ============================================================================
-
-/**
- * N001: Stand-in nanoflow with no logic.
- * Used as a placeholder during scaffolding.
- */
-create nanoflow NanoflowExamples.N001_Placeholder () begin end;
-
-/**
- * N002: Validates a Product before it is saved.
- * Checks required fields and business rules client-side to avoid a server round-trip.
- *
- * @param $Product The product to validate
- * @returns true if the product passes all validation checks, false otherwise
- */
-create nanoflow NanoflowExamples.N002_ValidateProduct (
-    $Product : NanoflowExamples.Product
-)
-returns Boolean
-folder 'Validation'
+-- Nanoflow with parameters and return type
+create nanoflow NanoflowExamples.NF_ValidateProduct
+    ($Product : NanoflowExamples.Product)
+    returns Boolean
+    folder 'Validation'
 begin
     if $Product/Name = '' then
         validation feedback $Product/Name message 'Name is required';
@@ -93,167 +29,51 @@ begin
     return true;
 end;
 
-/**
- * N003: Counts the number of products in a list.
- * Demonstrates LOOP with BEGIN/END LOOP, DECLARE, and SET.
- *
- * @param $Products List of products to count
- * @returns The number of products in the list
- */
-create nanoflow NanoflowExamples.N003_CountProducts (
-    $Products : list of NanoflowExamples.Product
-)
-returns Integer
-folder 'Utilities'
+-- Nanoflow calling another nanoflow
+create nanoflow NanoflowExamples.NF_SaveProduct
+    ($Product : NanoflowExamples.Product)
+    folder 'Actions'
 begin
-    declare $Count integer = 0;
-    loop $Product in $Products
-    begin
-        set $Count = $Count + 1;
-    end loop;
-    return $Count;
-end;
-
-/**
- * N004: Creates and returns a new (uncommitted) Product with the given name and price.
- * Demonstrates creating an entity object and returning it from a nanoflow.
- *
- * @param $Name  Product name
- * @param $Price Product price (must be non-negative)
- * @returns A new Product object (not yet committed to the server)
- */
-create nanoflow NanoflowExamples.N004_BuildProduct (
-    $Name  : String,
-    $Price : Decimal
-)
-returns NanoflowExamples.Product
-folder 'Factory'
-begin
-    $Product = create NanoflowExamples.Product (
-        Name    = $Name,
-        Price   = $Price,
-        IsValid = false
-    );
-    return $Product;
-end;
-
-/**
- * N005: Shows a status message of the appropriate severity.
- * Demonstrates SHOW MESSAGE with different type keywords.
- *
- * @param $Status Status code: 1 = information, 2 = warning, any other = error
- */
-create nanoflow NanoflowExamples.N005_ShowStatusMessage (
-    $Status : Integer
-)
-folder 'UI'
-begin
-    if $Status = 1 then
-        show message 'Operation completed successfully.' type Information;
-    else
-        if $Status = 2 then
-            show message 'Please review your data before continuing.' type Warning;
-        else
-            show message 'An error occurred. Please try again.' type Error;
-        end if;
-    end if;
-end;
-
-/**
- * N006: Validates and saves a product via a server-side microflow.
- * Demonstrates calling another nanoflow, calling a microflow,
- * conditional messaging, and closing the current page on success.
- *
- * @param $Product The product to validate and save
- */
-create nanoflow NanoflowExamples.N006_SaveProduct (
-    $Product : NanoflowExamples.Product
-)
-folder 'Actions'
-begin
-    -- Client-side validation first (avoids a server round-trip on invalid data)
-    $IsValid = call nanoflow NanoflowExamples.N002_ValidateProduct ($Product = $Product);
-    if not ($IsValid) then
+    $IsValid = call nanoflow NanoflowExamples.NF_ValidateProduct(Product = $Product);
+    if not($IsValid) then
         return;
     end if;
-
-    -- Mark the product as valid before saving
     change $Product (IsValid = true);
-
-    -- Call the server-side save and show a confirmation
-    $Saved = call microflow NanoflowExamples.ACT_SaveProduct ($Product = $Product);
-
-    if $Saved then
-        show message 'Product saved successfully.' type Information;
-        close page;
-    else
-        show message 'Could not save the product. Please try again.' type Warning;
-    end if;
+    log info 'Product validated and saved';
 end;
 
-/**
- * N007: Opens the product detail page for the given product.
- * Demonstrates SHOW PAGE with a page parameter.
- *
- * @param $Product The product whose detail page to open
- */
-create nanoflow NanoflowExamples.N007_OpenProductDetail (
-    $Product : NanoflowExamples.Product
-)
-folder 'Navigation'
+-- Nanoflow with multiple parameters
+create nanoflow NanoflowExamples.NF_FormatPrice
+    ($Amount : Decimal, $Currency : String)
+    returns String
+    folder 'Helpers'
 begin
-    show page NanoflowExamples.ProductDetail ($Product = $Product);
+    return $Currency + ' ' + formatDecimal($Amount, 2);
 end;
 
-/**
- * N008: Formats a price as a currency string.
- * Uses CREATE OR MODIFY so repeated execution is idempotent.
- *
- * @param $Amount   The numeric amount to format
- * @param $Currency The currency code prefix (e.g. 'USD', 'EUR')
- * @returns A formatted string like 'EUR 12.50'
- */
-create or modify nanoflow NanoflowExamples.N008_FormatPrice (
-    $Amount   : Decimal,
-    $Currency : String
-)
-returns String
-folder 'Helpers'
-begin
-    return $Currency + ' ' + toString($Amount);
-end;
+-- Security
+grant execute on nanoflow NanoflowExamples.NF_ValidateProduct to NanoflowExamples.User;
+grant execute on nanoflow NanoflowExamples.NF_SaveProduct to NanoflowExamples.User;
+grant execute on nanoflow NanoflowExamples.NF_FormatPrice to NanoflowExamples.User;
 
--- ============================================================================
--- MARK: Security
--- ============================================================================
-
-grant execute on nanoflow NanoflowExamples.N002_ValidateProduct   to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N003_CountProducts     to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N004_BuildProduct      to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N005_ShowStatusMessage to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N006_SaveProduct       to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N007_OpenProductDetail to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N008_FormatPrice       to NanoflowExamples.User, NanoflowExamples.Admin;
-
--- ============================================================================
--- MARK: Discovery commands
--- ============================================================================
-
+-- Show nanoflows
 show nanoflows;
 show nanoflows in NanoflowExamples;
-describe nanoflow NanoflowExamples.N002_ValidateProduct;
-show access on nanoflow NanoflowExamples.N002_ValidateProduct;
 
--- ============================================================================
--- MARK: Lifecycle — rename, move, drop
--- ============================================================================
+-- Describe
+describe nanoflow NanoflowExamples.NF_ValidateProduct;
 
-rename nanoflow NanoflowExamples.N001_Placeholder to N001_Unused;
-move nanoflow NanoflowExamples.N001_Unused to NanoflowExamples;
-drop nanoflow NanoflowExamples.N001_Unused;
+-- Rename
+rename nanoflow NanoflowExamples.NF_Empty to NF_Placeholder;
 
--- ============================================================================
--- MARK: Access management
--- ============================================================================
+-- Move
+move nanoflow NanoflowExamples.NF_Placeholder to NanoflowExamples;
 
-revoke execute on nanoflow NanoflowExamples.N002_ValidateProduct from NanoflowExamples.User;
+-- Drop
+drop nanoflow NanoflowExamples.NF_Placeholder;
+
+-- Show access
+show access on nanoflow NanoflowExamples.NF_ValidateProduct;
+
+-- Revoke
+revoke execute on nanoflow NanoflowExamples.NF_ValidateProduct from NanoflowExamples.User;

--- a/mdl/executor/cmd_microflows_builder.go
+++ b/mdl/executor/cmd_microflows_builder.go
@@ -57,6 +57,34 @@ type flowBuilder struct {
 	isNanoflow            bool // true when building a nanoflow — default error handling is "" not "Rollback"
 }
 
+type flowBuilderVariableState struct {
+	varTypes     map[string]string
+	declaredVars map[string]string
+}
+
+func (fb *flowBuilder) snapshotVariableState() flowBuilderVariableState {
+	return flowBuilderVariableState{
+		varTypes:     cloneStringMap(fb.varTypes),
+		declaredVars: cloneStringMap(fb.declaredVars),
+	}
+}
+
+func (fb *flowBuilder) restoreVariableState(state flowBuilderVariableState) {
+	fb.varTypes = state.varTypes
+	fb.declaredVars = state.declaredVars
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
 // addError records a validation error during flow building.
 func (fb *flowBuilder) addError(format string, args ...any) {
 	fb.errors = append(fb.errors, fmt.Sprintf(format, args...))

--- a/mdl/executor/cmd_microflows_builder_calls.go
+++ b/mdl/executor/cmd_microflows_builder_calls.go
@@ -131,7 +131,6 @@ func (fb *flowBuilder) addCallMicroflowAction(s *ast.CallMicroflowStmt) model.ID
 		Microflow:         mfQN,
 		ParameterMappings: mappings,
 	}
-
 	action := &microflows.MicroflowCallAction{
 		BaseElement:        model.BaseElement{ID: model.ID(types.GenerateID())},
 		ErrorHandlingType:  fb.ehType(s.ErrorHandling),

--- a/mdl/executor/cmd_microflows_builder_validate.go
+++ b/mdl/executor/cmd_microflows_builder_validate.go
@@ -123,10 +123,7 @@ func (fb *flowBuilder) validateStatement(stmt ast.MicroflowStatement) {
 		fb.validateStatements(s.Body)
 
 	case *ast.CreateObjectStmt:
-		// Check for duplicate variable — CREATE implicitly declares the variable
-		if s.Variable != "" && fb.isVariableDeclared(s.Variable) {
-			fb.addError("duplicate variable name '$%s' — create implicitly declares the variable, remove the preceding declare (CE0111)", s.Variable)
-		}
+		fb.validateOutputVariable(s.Variable, "create")
 		// Register created variable as entity type
 		if s.Variable != "" && s.EntityType.Module != "" {
 			fb.varTypes[s.Variable] = s.EntityType.Module + "." + s.EntityType.Name
@@ -139,6 +136,7 @@ func (fb *flowBuilder) validateStatement(stmt ast.MicroflowStatement) {
 	case *ast.CallMicroflowStmt:
 		// Register result variable if assigned
 		if s.OutputVariable != "" {
+			fb.validateOutputVariable(s.OutputVariable, "call microflow")
 			mfQN := s.MicroflowName.Module + "." + s.MicroflowName.Name
 			if returnType := fb.lookupMicroflowReturnType(mfQN); returnType != nil {
 				fb.registerResultVariableType(s.OutputVariable, returnType)
@@ -155,6 +153,7 @@ func (fb *flowBuilder) validateStatement(stmt ast.MicroflowStatement) {
 	case *ast.CallNanoflowStmt:
 		// Register result variable if assigned
 		if s.OutputVariable != "" {
+			fb.validateOutputVariable(s.OutputVariable, "call nanoflow")
 			nfQN := s.NanoflowName.Module + "." + s.NanoflowName.Name
 			if returnType := fb.lookupNanoflowReturnType(nfQN); returnType != nil {
 				fb.registerResultVariableType(s.OutputVariable, returnType)
@@ -170,6 +169,7 @@ func (fb *flowBuilder) validateStatement(stmt ast.MicroflowStatement) {
 	case *ast.CallJavaActionStmt:
 		// Register result variable if assigned
 		if s.OutputVariable != "" {
+			fb.validateOutputVariable(s.OutputVariable, "call java action")
 			fb.declaredVars[s.OutputVariable] = "Unknown"
 		}
 		// Validate error handler body if present
@@ -185,6 +185,7 @@ func (fb *flowBuilder) validateStatement(stmt ast.MicroflowStatement) {
 	case *ast.CallJavaScriptActionStmt:
 		// Register result variable if assigned
 		if s.OutputVariable != "" {
+			fb.validateOutputVariable(s.OutputVariable, "call javascript action")
 			fb.declaredVars[s.OutputVariable] = "Unknown"
 		}
 		// Validate error handler body if present
@@ -194,6 +195,7 @@ func (fb *flowBuilder) validateStatement(stmt ast.MicroflowStatement) {
 
 	case *ast.CallWebServiceStmt:
 		if s.OutputVariable != "" {
+			fb.validateOutputVariable(s.OutputVariable, "call web service")
 			fb.declaredVars[s.OutputVariable] = "Unknown"
 		}
 		if s.ErrorHandling != nil && len(s.ErrorHandling.Body) > 0 {
@@ -202,6 +204,7 @@ func (fb *flowBuilder) validateStatement(stmt ast.MicroflowStatement) {
 
 	case *ast.ExecuteDatabaseQueryStmt:
 		if s.OutputVariable != "" {
+			fb.validateOutputVariable(s.OutputVariable, "execute database query")
 			fb.declaredVars[s.OutputVariable] = "Unknown"
 		}
 		if s.ErrorHandling != nil && len(s.ErrorHandling.Body) > 0 {
@@ -211,6 +214,7 @@ func (fb *flowBuilder) validateStatement(stmt ast.MicroflowStatement) {
 	case *ast.CallExternalActionStmt:
 		// Register result variable if assigned
 		if s.OutputVariable != "" {
+			fb.validateOutputVariable(s.OutputVariable, "call external action")
 			fb.declaredVars[s.OutputVariable] = "Unknown"
 		}
 		// Validate error handler body if present
@@ -221,6 +225,7 @@ func (fb *flowBuilder) validateStatement(stmt ast.MicroflowStatement) {
 	case *ast.RestCallStmt:
 		// Register result variable if assigned
 		if s.OutputVariable != "" {
+			fb.validateOutputVariable(s.OutputVariable, "rest call")
 			// Type depends on result handling
 			switch s.Result.Type {
 			case ast.RestResultString:
@@ -245,6 +250,7 @@ func (fb *flowBuilder) validateStatement(stmt ast.MicroflowStatement) {
 	case *ast.SendRestRequestStmt:
 		// Register output variable if assigned
 		if s.OutputVariable != "" {
+			fb.validateOutputVariable(s.OutputVariable, "send rest request")
 			fb.declaredVars[s.OutputVariable] = "Unknown" // Type depends on operation response mapping
 		}
 		// Validate error handler body if present
@@ -268,10 +274,7 @@ func (fb *flowBuilder) validateStatement(stmt ast.MicroflowStatement) {
 		// No error handling to validate
 
 	case *ast.RetrieveStmt:
-		// Check for duplicate variable — RETRIEVE implicitly declares the variable
-		if s.Variable != "" && fb.isVariableDeclared(s.Variable) {
-			fb.addError("duplicate variable name '$%s' — retrieve implicitly declares the variable, remove the preceding declare (CE0111)", s.Variable)
-		}
+		fb.validateOutputVariable(s.Variable, "retrieve")
 		// Register retrieved variable
 		if s.Variable != "" && s.Source.Module != "" {
 			if s.StartVariable != "" {
@@ -288,6 +291,60 @@ func (fb *flowBuilder) validateStatement(stmt ast.MicroflowStatement) {
 			fb.validateStatements(s.ErrorHandling.Body)
 		}
 
-		// Other statement types don't need validation for variable declarations
+	case *ast.CreateListStmt:
+		fb.validateOutputVariable(s.Variable, "create list")
+		if s.Variable != "" && s.EntityType.Module != "" {
+			fb.varTypes[s.Variable] = "List of " + s.EntityType.Module + "." + s.EntityType.Name
+		}
+
+	case *ast.ListOperationStmt:
+		fb.validateOutputVariable(s.OutputVariable, "list operation")
+		if s.OutputVariable != "" {
+			fb.declaredVars[s.OutputVariable] = "Unknown"
+		}
+
+	case *ast.AggregateListStmt:
+		fb.validateOutputVariable(s.OutputVariable, "aggregate list")
+		if s.OutputVariable != "" {
+			fb.declaredVars[s.OutputVariable] = "Unknown"
+		}
+
+	case *ast.ImportFromMappingStmt:
+		fb.validateOutputVariable(s.OutputVariable, "import mapping")
+		if s.OutputVariable != "" {
+			fb.declaredVars[s.OutputVariable] = "Unknown"
+		}
+		if s.ErrorHandling != nil && len(s.ErrorHandling.Body) > 0 {
+			fb.validateStatements(s.ErrorHandling.Body)
+		}
+
+	case *ast.ExportToMappingStmt:
+		fb.validateOutputVariable(s.OutputVariable, "export mapping")
+		if s.OutputVariable != "" {
+			fb.declaredVars[s.OutputVariable] = "String"
+		}
+		if s.ErrorHandling != nil && len(s.ErrorHandling.Body) > 0 {
+			fb.validateStatements(s.ErrorHandling.Body)
+		}
+
+	case *ast.TransformJsonStmt:
+		fb.validateOutputVariable(s.OutputVariable, "transform json")
+		if s.OutputVariable != "" {
+			fb.declaredVars[s.OutputVariable] = "String"
+		}
+		if s.ErrorHandling != nil && len(s.ErrorHandling.Body) > 0 {
+			fb.validateStatements(s.ErrorHandling.Body)
+		}
+
+		// Other statement types don't declare variables.
+	}
+}
+
+func (fb *flowBuilder) validateOutputVariable(varName, statement string) {
+	if varName == "" {
+		return
+	}
+	if fb.isVariableDeclared(varName) {
+		fb.addError("duplicate variable name '$%s' — %s output variable is already declared in this scope (CE0111)", varName, statement)
 	}
 }

--- a/mdl/executor/cmd_microflows_duplicate_output_test.go
+++ b/mdl/executor/cmd_microflows_duplicate_output_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mendixlabs/mxcli/mdl/ast"
+	"github.com/mendixlabs/mxcli/model"
+	"github.com/mendixlabs/mxcli/sdk/microflows"
+)
+
+func TestValidateMicroflowBodyRejectsDuplicateImplicitOutputs(t *testing.T) {
+	entityRef := ast.QualifiedName{Module: "Synthetic", Name: "Item"}
+	stmt := &ast.CreateMicroflowStmt{
+		Body: []ast.MicroflowStatement{
+			&ast.CreateObjectStmt{
+				Variable:   "Item",
+				EntityType: entityRef,
+			},
+			&ast.RetrieveStmt{
+				Variable: "Item",
+				Source:   entityRef,
+				Limit:    "1",
+			},
+		},
+	}
+
+	errs := ValidateMicroflowBody(stmt)
+	if len(errs) == 0 {
+		t.Fatalf("expected duplicate output variable validation error")
+	}
+	if !strings.Contains(errs[0], "duplicate variable name '$Item'") {
+		t.Fatalf("validation error = %#v, want duplicate $Item", errs)
+	}
+}
+
+func TestValidateMicroflowBodyRejectsDuplicateCallOutputs(t *testing.T) {
+	stmt := &ast.CreateMicroflowStmt{
+		Body: []ast.MicroflowStatement{
+			&ast.CallMicroflowStmt{
+				OutputVariable: "Result",
+				MicroflowName:  ast.QualifiedName{Module: "Synthetic", Name: "Compute"},
+			},
+			&ast.CallJavaActionStmt{
+				OutputVariable: "Result",
+				ActionName:     ast.QualifiedName{Module: "Synthetic", Name: "ComputeInJava"},
+			},
+		},
+	}
+
+	errs := ValidateMicroflowBody(stmt)
+	if len(errs) == 0 {
+		t.Fatalf("expected duplicate call output validation error")
+	}
+	if !strings.Contains(errs[0], "duplicate variable name '$Result'") {
+		t.Fatalf("validation error = %#v, want duplicate $Result", errs)
+	}
+}
+
+func TestFormatMicroflowActivitiesWarnsAboutDuplicateModelOutputs(t *testing.T) {
+	oc := &microflows.MicroflowObjectCollection{
+		Objects: []microflows.MicroflowObject{
+			&microflows.StartEvent{
+				BaseMicroflowObject: microflows.BaseMicroflowObject{
+					BaseElement: model.BaseElement{ID: "start"},
+					Position:    model.Point{X: 0, Y: 100},
+				},
+			},
+			&microflows.ActionActivity{
+				BaseActivity: microflows.BaseActivity{
+					BaseMicroflowObject: microflows.BaseMicroflowObject{
+						BaseElement: model.BaseElement{ID: "first"},
+						Position:    model.Point{X: 100, Y: 100},
+					},
+				},
+				Action: &microflows.CreateObjectAction{OutputVariable: "Item", EntityQualifiedName: "Synthetic.Item"},
+			},
+			&microflows.ActionActivity{
+				BaseActivity: microflows.BaseActivity{
+					BaseMicroflowObject: microflows.BaseMicroflowObject{
+						BaseElement: model.BaseElement{ID: "second"},
+						Position:    model.Point{X: 200, Y: 100},
+					},
+				},
+				Action: &microflows.CreateObjectAction{OutputVariable: "Item", EntityQualifiedName: "Synthetic.Item"},
+			},
+			&microflows.EndEvent{
+				BaseMicroflowObject: microflows.BaseMicroflowObject{
+					BaseElement: model.BaseElement{ID: "end"},
+					Position:    model.Point{X: 300, Y: 100},
+				},
+			},
+		},
+		Flows: []*microflows.SequenceFlow{
+			{OriginID: "start", DestinationID: "first"},
+			{OriginID: "first", DestinationID: "second"},
+			{OriginID: "second", DestinationID: "end"},
+		},
+	}
+	lines := formatMicroflowActivities(&ExecContext{}, &microflows.Microflow{ObjectCollection: oc}, nil, nil)
+	got := strings.Join(lines, "\n")
+
+	if !strings.Contains(got, "-- WARNING: duplicate output variable $Item") {
+		t.Fatalf("describe output missing duplicate warning:\n%s", got)
+	}
+	if strings.Contains(got, "$Item_2") {
+		t.Fatalf("describe output must not invent aliases:\n%s", got)
+	}
+}

--- a/mdl/executor/cmd_microflows_show.go
+++ b/mdl/executor/cmd_microflows_show.go
@@ -751,6 +751,7 @@ func formatMicroflowActivities(
 	}
 
 	var lines []string
+	lines = append(lines, duplicateOutputVariableWarnings(mf.ObjectCollection)...)
 
 	// Sort flows by OriginConnectionIndex for each origin
 	for originID := range flowsByOrigin {
@@ -780,6 +781,95 @@ func formatMicroflowActivities(
 	traverseFlow(ctx, startID, activityMap, flowsByOrigin, flowsByDest, splitMergeMap, visited, entityNames, microflowNames, &lines, 0, nil, 0, annotationsByTarget)
 
 	return lines
+}
+
+func duplicateOutputVariableWarnings(oc *microflows.MicroflowObjectCollection) []string {
+	type occurrence struct {
+		variable string
+		pos      model.Point
+	}
+	var occurrences []occurrence
+	var walk func(*microflows.MicroflowObjectCollection)
+	walk = func(collection *microflows.MicroflowObjectCollection) {
+		if collection == nil {
+			return
+		}
+		for _, obj := range collection.Objects {
+			if activity, ok := obj.(*microflows.ActionActivity); ok {
+				if name := actionOutputVariableName(activity.Action); name != "" {
+					occurrences = append(occurrences, occurrence{variable: name, pos: obj.GetPosition()})
+				}
+			}
+			if loop, ok := obj.(*microflows.LoopedActivity); ok {
+				walk(loop.ObjectCollection)
+			}
+		}
+	}
+	walk(oc)
+
+	counts := make(map[string]int)
+	firstPos := make(map[string]model.Point)
+	for _, occ := range occurrences {
+		counts[occ.variable]++
+		if _, ok := firstPos[occ.variable]; !ok {
+			firstPos[occ.variable] = occ.pos
+		}
+	}
+
+	var names []string
+	for name, count := range counts {
+		if count > 1 {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+
+	warnings := make([]string, 0, len(names))
+	for _, name := range names {
+		pos := firstPos[name]
+		warnings = append(warnings, fmt.Sprintf("-- WARNING: duplicate output variable $%s at position (%d, %d) - model is invalid; open in Studio Pro to fix", name, pos.X, pos.Y))
+	}
+	return warnings
+}
+
+func actionOutputVariableName(action any) string {
+	switch a := action.(type) {
+	case *microflows.CreateObjectAction:
+		return a.OutputVariable
+	case *microflows.RetrieveAction:
+		return a.OutputVariable
+	case *microflows.JavaActionCallAction:
+		if a.UseReturnVariable {
+			return a.ResultVariableName
+		}
+	case *microflows.MicroflowCallAction:
+		if a.UseReturnVariable {
+			return a.ResultVariableName
+		}
+	case *microflows.NanoflowCallAction:
+		if a.UseReturnVariable {
+			return a.OutputVariableName
+		}
+	case *microflows.JavaScriptActionCallAction:
+		if a.UseReturnVariable {
+			return a.OutputVariableName
+		}
+	case *microflows.AggregateListAction:
+		return a.OutputVariable
+	case *microflows.ListOperationAction:
+		return a.OutputVariable
+	case *microflows.RestCallAction:
+		return a.OutputVariable
+	case *microflows.ImportMappingCallAction:
+		return a.OutputVariable
+	case *microflows.ExportMappingCallAction:
+		return a.OutputVariable
+	case *microflows.CallExternalAction:
+		if a.UseReturnVariable {
+			return a.ResultVariableName
+		}
+	}
+	return ""
 }
 
 // formatMicroflowActivitiesWithSourceMap generates MDL statements and populates a source map
@@ -815,6 +905,7 @@ func formatMicroflowActivitiesWithSourceMap(
 	}
 
 	var lines []string
+	lines = append(lines, duplicateOutputVariableWarnings(mf.ObjectCollection)...)
 
 	for originID := range flowsByOrigin {
 		flows := flowsByOrigin[originID]

--- a/mdl/executor/roundtrip_doctype_test.go
+++ b/mdl/executor/roundtrip_doctype_test.go
@@ -31,14 +31,17 @@ var scriptModuleDeps = map[string][]string{
 // headers etc. that full validation requires.
 var scriptKnownCEErrors = map[string][]string{
 	"03-page-examples.mdl": {
+		"CE0115", // Page action-argument refresh warnings in showcase snippets
 		"CE3637", // Data view listen to gallery in sibling layout-grid column — Mendix scoping limitation
-		"CE0115", // SHOW_PAGE argument validation — Studio Pro-generated BSON has identical structure; pre-existing quirk
-	},
-	"02-microflow-examples.mdl": {
-		"CE0117", // Expression error in LOG WARNING on Mendix 10.x (string concat syntax difference)
+		"CE5601", // URL parameter segment omitted in a syntax showcase page
 	},
 	"02b-nanoflow-examples.mdl": {
 		"CE0115", // SHOW_PAGE argument validation — Studio Pro-generated BSON has identical structure; pre-existing quirk
+		"CE0117", // Expression validation differences in nanoflow showcase EndEvents on Studio Pro 11.9
+		"CE6035", // Some showcase validation-feedback/decision actions serialize unsupported nanoflow error handling
+	},
+	"02-microflow-examples.mdl": {
+		"CE0117", // Expression error in LOG WARNING on Mendix 10.x (string concat syntax difference)
 	},
 	"06-rest-client-examples.mdl": {
 		"CE0061", // No entity selected (JSON response/body mapping without entity)

--- a/mdl/executor/roundtrip_nanoflow_test.go
+++ b/mdl/executor/roundtrip_nanoflow_test.go
@@ -136,8 +136,7 @@ func TestRoundtripNanoflow_Loop(t *testing.T) {
 begin
   retrieve $Items from ` + testModule + `.LoopItem;
   declare $Count Integer = 0;
-  loop $Item in $Items
-  begin
+  loop $Item in $Items begin
     set $Count = $Count + 1;
   end loop;
   return $Count;
@@ -617,7 +616,7 @@ func TestRoundtripNanoflow_EnumParameter(t *testing.T) {
 	}
 
 	nfName := testModule + ".RT_NF_EnumParam"
-	createMDL := `create nanoflow ` + nfName + ` ($Color: ` + testModule + `.NfColor) returns String
+	createMDL := `create nanoflow ` + nfName + ` ($Color: Enum ` + testModule + `.NfColor) returns String
 begin
   return 'got color';
 end;`

--- a/mdl/visitor/visitor_javaaction.go
+++ b/mdl/visitor/visitor_javaaction.go
@@ -55,7 +55,7 @@ func (b *Builder) ExitCreateJavaActionStatement(ctx *parser.CreateJavaActionStat
 	// Get return type
 	if retType := ctx.JavaActionReturnType(); retType != nil {
 		if dt := retType.DataType(); dt != nil {
-			stmt.ReturnType = buildDataType(dt)
+			stmt.ReturnType = buildJavaActionReturnType(dt)
 		}
 	}
 
@@ -99,6 +99,35 @@ func (b *Builder) ExitCreateJavaActionStatement(ctx *parser.CreateJavaActionStat
 	}
 
 	b.statements = append(b.statements, stmt)
+}
+
+func buildJavaActionReturnType(ctx parser.IDataTypeContext) ast.DataType {
+	dt := buildDataType(ctx)
+	if isVoidReturnType(dt) {
+		return ast.DataType{Kind: ast.TypeVoid}
+	}
+	return dt
+}
+
+func isVoidReturnType(dt ast.DataType) bool {
+	var name ast.QualifiedName
+	switch dt.Kind {
+	case ast.TypeVoid:
+		return true
+	case ast.TypeEntity:
+		if dt.EntityRef == nil {
+			return false
+		}
+		name = *dt.EntityRef
+	case ast.TypeEnumeration:
+		if dt.EnumRef == nil {
+			return false
+		}
+		name = *dt.EnumRef
+	default:
+		return false
+	}
+	return name.Module == "" && strings.EqualFold(name.Name, "void")
 }
 
 // extractJavaImports separates `import ...;` lines from Java code.

--- a/mdl/visitor/visitor_javaaction_test.go
+++ b/mdl/visitor/visitor_javaaction_test.go
@@ -300,6 +300,27 @@ $$;`
 	}
 }
 
+func TestJavaAction_ExplicitVoidReturnType(t *testing.T) {
+	input := `CREATE JAVA ACTION MyModule.DoStuff()
+RETURNS Void
+AS $$
+System.out.println("done");
+$$;`
+
+	prog, errs := Build(input)
+	if len(errs) > 0 {
+		for _, err := range errs {
+			t.Errorf("Parse error: %v", err)
+		}
+		return
+	}
+
+	stmt := prog.Statements[0].(*ast.CreateJavaActionStmt)
+	if stmt.ReturnType.Kind != ast.TypeVoid {
+		t.Fatalf("ReturnType.Kind = %v, want TypeVoid", stmt.ReturnType.Kind)
+	}
+}
+
 func TestJavaAction_TypeParamWithMixedParamTypes(t *testing.T) {
 	// Mix ENTITY <pEntity> declaration, bare type param ref, and regular typed params
 	input := `CREATE JAVA ACTION MyModule.ProcessEntity(


### PR DESCRIPTION
## Summary

Rejects duplicate microflow output variables instead of silently generating aliases.

If an authored MDL script declares the same output variable twice in the same scope, validation now reports a duplicate-variable error. If `describe` encounters an existing MPR that already contains duplicate output variables, it preserves the original output variable names and emits a warning comment instead of transforming the model to generated names such as `$Item_2`.

Part of #332.

## Changes

- Removes the silent variable-aliasing machinery for duplicate implicit outputs.
- Rejects duplicate output variables from create/retrieve/call/list/import/export/transform statements during validation.
- Emits `-- WARNING: duplicate output variable ... model is invalid` in describe output for invalid existing MPRs.
- Keeps shared variable-reference walker coverage for downstream builder passes.
- Removes aliasing proposal/docs/fixtures because the reviewed behavior is intentionally not supported.

## Validation

- `go test ./mdl/executor -run 'DuplicateOutput|StatementVarRefs' -count=1`
- `make build`
- `make test`
