### PR TITLE
fix: write valid show-page parameter mappings

### DIFF
--- a/mdl-examples/bug-tests/295-showpage-parameter-mapping-validity.mdl
+++ b/mdl-examples/bug-tests/295-showpage-parameter-mapping-validity.mdl
@@ -1,0 +1,56 @@
+-- ============================================================================
+-- Bug #295: SHOW PAGE parameter mappings produced unopenable Studio Pro MPRs
+-- ============================================================================
+--
+-- Symptom (before fix):
+--   When `mxcli exec` wrote a microflow `show page X (Param: $Var)`, the
+--   `Forms$PageParameterMapping.Variable` field was serialized as BSON
+--   `null`. Studio Pro rejected this on project load with a runtime
+--   exception, making the entire MPR unopenable. The originating bug
+--   also affected SNIPPET ACTIONBUTTON SHOW_PAGE (#295), but the root
+--   cause is in the writer's serialization of PageParameterMapping.
+--
+--   Additionally, `FormSettings.ParameterMappings` used the mapping count
+--   as the BSON storage-list first element instead of Mendix's storage-list
+--   marker (`int32(2)`).
+--
+-- After fix:
+--   `writer_microflow_actions.go` now writes
+--   - `Variable` as a valid empty `Forms$PageVariable` object via
+--     `emptyPageVariable()`
+--   - `ParameterMappings` storage-list with the constant marker `int32(2)`
+--
+-- Usage:
+--   mxcli exec mdl-examples/bug-tests/295-showpage-parameter-mapping-validity.mdl -p app.mpr
+--   mxcli -p app.mpr -c "describe microflow BugTest295.ACT_OpenProductPage"
+--   `mx check` against the resulting MPR must report 0 errors and the
+--   project must be openable in Studio Pro.
+-- ============================================================================
+
+create module BugTest295;
+
+create entity BugTest295.Product (
+  Name : string(100)
+);
+/
+
+create page BugTest295.Product_Detail
+(
+  params: {
+    $Product: BugTest295.Product
+  },
+  title: 'Product Detail',
+  layout: Atlas_Core.Atlas_Default
+)
+{
+  dynamictext txtName (content: 'Product detail', rendermode: H4)
+}
+/
+
+create microflow BugTest295.ACT_OpenProductPage (
+  $Product: BugTest295.Product
+)
+begin
+  show page BugTest295.Product_Detail (Product: $Product);
+end;
+/

--- a/sdk/mpr/showpage_roundtrip_test.go
+++ b/sdk/mpr/showpage_roundtrip_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mendixlabs/mxcli/model"
 	"github.com/mendixlabs/mxcli/sdk/microflows"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // TestShowPageAction_Roundtrip verifies that a ShowPageAction with parameters
@@ -59,6 +60,59 @@ func TestShowPageAction_Roundtrip(t *testing.T) {
 	}
 	if pm.Argument != "$Product" {
 		t.Errorf("Argument = %q, want %q", pm.Argument, "$Product")
+	}
+}
+
+func TestShowPageAction_WritesValidPageParameterMapping(t *testing.T) {
+	action := &microflows.ShowPageAction{
+		BaseElement: model.BaseElement{ID: "test-action-id"},
+		PageName:    "Sales.Product_NewEdit",
+		PageParameterMappings: []*microflows.PageParameterMapping{
+			{
+				BaseElement: model.BaseElement{ID: "test-mapping-id"},
+				Parameter:   "Sales.Product_NewEdit.Product",
+				Argument:    "$Product",
+			},
+		},
+	}
+
+	doc := serializeMicroflowAction(action)
+	data, err := bson.Marshal(doc)
+	if err != nil {
+		t.Fatalf("failed to marshal BSON: %v", err)
+	}
+
+	var raw map[string]any
+	if err := bson.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("failed to unmarshal BSON: %v", err)
+	}
+
+	formSettings := toMap(raw["FormSettings"])
+	if formSettings == nil {
+		t.Fatal("FormSettings missing")
+	}
+
+	mappings, ok := formSettings["ParameterMappings"].(primitive.A)
+	if !ok {
+		t.Fatalf("ParameterMappings type = %T, want primitive.A", formSettings["ParameterMappings"])
+	}
+	if len(mappings) != 2 {
+		t.Fatalf("ParameterMappings length = %d, want marker plus one mapping", len(mappings))
+	}
+	if marker, ok := mappings[0].(int32); !ok || marker != 2 {
+		t.Fatalf("ParameterMappings marker = %#v, want int32(2)", mappings[0])
+	}
+
+	mapping := toMap(mappings[1])
+	if mapping == nil {
+		t.Fatal("PageParameterMapping missing")
+	}
+	variable := toMap(mapping["Variable"])
+	if variable == nil {
+		t.Fatal("Variable is nil; Studio Pro rejects null page parameter mapping variables")
+	}
+	if got := extractString(variable["$Type"]); got != "Forms$PageVariable" {
+		t.Fatalf("Variable $Type = %q, want Forms$PageVariable", got)
 	}
 }
 

--- a/sdk/mpr/writer_microflow_actions.go
+++ b/sdk/mpr/writer_microflow_actions.go
@@ -345,15 +345,16 @@ func serializeMicroflowAction(action microflows.MicroflowAction) bson.D {
 			formSettingsID = model.ID(generateUUID())
 		}
 
-		// Build ParameterMappings inside FormSettings
-		paramMappings := bson.A{int32(len(a.PageParameterMappings))}
+		// Build ParameterMappings inside FormSettings. Mendix storage lists use
+		// a marker as the first element; it is not the number of mappings.
+		paramMappings := bson.A{int32(2)}
 		for _, pm := range a.PageParameterMappings {
 			mapping := bson.D{
 				{Key: "$ID", Value: idToBsonBinary(string(pm.ID))},
 				{Key: "$Type", Value: "Forms$PageParameterMapping"}, // Forms$, not Microflows$
 				{Key: "Argument", Value: pm.Argument},
 				{Key: "Parameter", Value: pm.Parameter}, // BY_NAME_REFERENCE
-				{Key: "Variable", Value: nil},
+				{Key: "Variable", Value: emptyPageVariable()},
 			}
 			paramMappings = append(paramMappings, mapping)
 		}
@@ -466,6 +467,17 @@ func serializeMicroflowAction(action microflows.MicroflowAction) bson.D {
 
 	default:
 		return nil
+	}
+}
+
+func emptyPageVariable() bson.D {
+	return bson.D{
+		{Key: "$ID", Value: idToBsonBinary(generateUUID())},
+		{Key: "$Type", Value: "Forms$PageVariable"},
+		{Key: "PageParameter", Value: ""},
+		{Key: "SnippetParameter", Value: ""},
+		{Key: "UseAllPages", Value: false},
+		{Key: "Widget", Value: ""},
 	}
 }
 


### PR DESCRIPTION
## Summary

- writes `Forms$PageParameterMapping.Variable` as a valid empty `Forms$PageVariable` object instead of `null`
- uses the Mendix storage-list marker for `FormSettings.ParameterMappings` rather than the mapping count
- adds a BSON-level regression test for the serialized show-page parameter mapping shape

## Why

Studio Pro rejects `PageParameterMapping.Variable = null` while loading a project. `mxcli exec` could succeed, but the resulting MPR was not openable when a show-page action contained page parameter mappings.

## Validation

- `make build`
- `make lint-go`
- `make test`

Closes #295.
Related to #332.