### PR TITLE
fix: refresh empty change-object actions

### DIFF
--- a/mdl-examples/bug-tests/339-empty-change-refresh-in-client.mdl
+++ b/mdl-examples/bug-tests/339-empty-change-refresh-in-client.mdl
@@ -1,0 +1,33 @@
+-- ============================================================================
+-- Bug #339: Empty change-object actions must refresh in client
+-- ============================================================================
+--
+-- Symptom (before fix):
+--   Rebuilding an empty change-object activity from MDL wrote a non-committing
+--   ChangeObjectAction with no member changes and RefreshInClient=false.
+--   Studio Pro / mx check rejected that activity with CE0032:
+--     "Change action has no items specified and does not commit the object."
+--
+-- After fix:
+--   `change $Object;` is serialized as a refresh-only change action by setting
+--   RefreshInClient=true. Although the CE0032 text mentions only items/commit,
+--   empirical mx check validation accepts refresh as the third valid escape.
+--
+-- Usage:
+--   mxcli exec mdl-examples/bug-tests/339-empty-change-refresh-in-client.mdl -p app.mpr
+--   mx check app.mpr
+--   Expected: 0 new CE0032 errors for BugTest339.MF_RefreshOnlyChange.
+-- ============================================================================
+
+create module BugTest339;
+
+create entity BugTest339.Item (
+  Name: String(100)
+);
+
+create microflow BugTest339.MF_RefreshOnlyChange ()
+begin
+  $Item = create BugTest339.Item;
+  change $Item;
+end;
+/

--- a/mdl/executor/bugfix_regression_test.go
+++ b/mdl/executor/bugfix_regression_test.go
@@ -675,6 +675,27 @@ func TestCallMicroflowResultType_ResolvesSubsequentChangeMember(t *testing.T) {
 	}
 }
 
+func TestEmptyChangeObjectRefreshesInClient(t *testing.T) {
+	fb := &flowBuilder{posX: 100, posY: 100, spacing: HorizontalSpacing}
+
+	id := fb.addChangeObjectAction(&ast.ChangeObjectStmt{Variable: "Object"})
+	if id == "" || len(fb.objects) != 1 {
+		t.Fatalf("expected one change object activity, got id=%q objects=%d", id, len(fb.objects))
+	}
+
+	activity, ok := fb.objects[0].(*microflows.ActionActivity)
+	if !ok {
+		t.Fatalf("object type = %T, want *microflows.ActionActivity", fb.objects[0])
+	}
+	action, ok := activity.Action.(*microflows.ChangeObjectAction)
+	if !ok {
+		t.Fatalf("action type = %T, want *microflows.ChangeObjectAction", activity.Action)
+	}
+	if !action.RefreshInClient {
+		t.Fatal("empty change object must refresh in client to remain valid without member changes or commit")
+	}
+}
+
 func TestCallMicroflowUnknownResultTypeStillDeclaresVariable(t *testing.T) {
 	fb := &flowBuilder{
 		varTypes:     map[string]string{"Result": "Old.ModuleEntity"},

--- a/mdl/executor/cmd_microflows_builder_actions.go
+++ b/mdl/executor/cmd_microflows_builder_actions.go
@@ -240,9 +240,12 @@ func (fb *flowBuilder) addRollbackAction(s *ast.RollbackStmt) model.ID {
 // addChangeObjectAction creates a CHANGE statement.
 func (fb *flowBuilder) addChangeObjectAction(s *ast.ChangeObjectStmt) model.ID {
 	action := &microflows.ChangeObjectAction{
-		BaseElement:     model.BaseElement{ID: model.ID(types.GenerateID())},
-		ChangeVariable:  s.Variable,
-		Commit:          microflows.CommitTypeNo,
+		BaseElement:    model.BaseElement{ID: model.ID(types.GenerateID())},
+		ChangeVariable: s.Variable,
+		Commit:         microflows.CommitTypeNo,
+		// Studio Pro rejects an empty non-committing change action unless it
+		// refreshes in client. The CE0032 message mentions only items/commit,
+		// but mx check accepts RefreshInClient=true as the third valid escape.
 		RefreshInClient: len(s.Changes) == 0,
 	}
 

--- a/mdl/executor/cmd_microflows_builder_actions.go
+++ b/mdl/executor/cmd_microflows_builder_actions.go
@@ -243,7 +243,7 @@ func (fb *flowBuilder) addChangeObjectAction(s *ast.ChangeObjectStmt) model.ID {
 		BaseElement:     model.BaseElement{ID: model.ID(types.GenerateID())},
 		ChangeVariable:  s.Variable,
 		Commit:          microflows.CommitTypeNo,
-		RefreshInClient: false,
+		RefreshInClient: len(s.Changes) == 0,
 	}
 
 	// Look up entity type from variable scope


### PR DESCRIPTION
## Summary

- sets `RefreshInClient` when rebuilding `change $Object;` with no member assignments
- keeps explicit member-change actions unchanged
- adds a builder regression test for the empty change-object case

## Why

An empty, non-committing `ChangeObjectAction` without refresh is invalid in Studio Pro and reports CE0032. Existing models can use empty change activities as refresh-only actions, and the MDL form currently has no explicit `refresh` modifier for `change` statements, so the builder needs to preserve validity by inferring refresh for empty changes.

## Validation

- `make build`
- `make lint-go`
- `make test`

Closes #339.
Related to #332.