### PR TITLE
fix: preserve attribute-based list operations

### DIFF
--- a/mdl-examples/bug-tests/343-list-attribute-find-filter.mdl
+++ b/mdl-examples/bug-tests/343-list-attribute-find-filter.mdl
@@ -1,0 +1,56 @@
+-- ============================================================================
+-- Bug #343: Attribute-based find/filter list operations rebuilt as expressions
+-- ============================================================================
+--
+-- Symptom (before fix):
+--   `find($List, Attribute = expression)` and
+--   `filter($List, Attribute = expression)` could be described correctly
+--   from existing models, but `mxcli exec` always rebuilt them as
+--   `FindByExpression` / `FilterByExpression`. Studio Pro's expression
+--   validator then surfaced CE0117 on the list operation activity even
+--   though the MDL source had not been edited.
+--
+-- After fix:
+--   The builder resolves the equality LHS to an attribute (or association)
+--   on the input list's element type and emits
+--   `Microflows$Find` / `Microflows$Filter` (`FindByAttributeOperation` /
+--   `FilterByAttributeOperation`) when possible. Complex conditions still
+--   fall back to the expression-based shape.
+--
+-- Usage:
+--   mxcli exec mdl-examples/bug-tests/343-list-attribute-find-filter.mdl -p app.mpr
+--   mxcli -p app.mpr -c "describe microflow BugTest343.MF_FindByAttribute"
+--   `mx check` against the resulting MPR must report 0 errors and the
+--   activities must not surface CE0117 in Studio Pro.
+-- ============================================================================
+
+create module BugTest343;
+
+create entity BugTest343.Item (
+  Name : string(100),
+  Active : boolean
+);
+/
+
+-- find by attribute equality — rebuild must emit Microflows$Find with
+-- attribute-operation shape, not FindByExpression.
+create microflow BugTest343.MF_FindByAttribute (
+  $Items: list of BugTest343.Item,
+  $Target: string
+)
+returns BugTest343.Item as $Found
+begin
+  $Found = find($Items, Name = $Target);
+end;
+/
+
+-- filter by attribute equality — rebuild must emit Microflows$Filter
+-- with attribute-operation shape, not FilterByExpression.
+create microflow BugTest343.MF_FilterByAttribute (
+  $Items: list of BugTest343.Item
+)
+returns list of BugTest343.Item as $Active
+begin
+  $Active = filter($Items, Active = true);
+end;
+/

--- a/mdl/executor/bugfix_regression_test.go
+++ b/mdl/executor/bugfix_regression_test.go
@@ -696,6 +696,53 @@ func TestEmptyChangeObjectRefreshesInClient(t *testing.T) {
 	}
 }
 
+func TestListFindAttributeEqualsExpressionUsesAttributeOperation(t *testing.T) {
+	fb := &flowBuilder{
+		posX:    100,
+		posY:    100,
+		spacing: HorizontalSpacing,
+		varTypes: map[string]string{
+			"Items": "List of Demo.Item",
+		},
+	}
+
+	id := fb.addListOperationAction(&ast.ListOperationStmt{
+		OutputVariable: "ExistingItem",
+		Operation:      ast.ListOpFind,
+		InputVariable:  "Items",
+		Condition: &ast.BinaryExpr{
+			Left:     &ast.IdentifierExpr{Name: "Code"},
+			Operator: "=",
+			Right: &ast.AttributePathExpr{
+				Variable: "IteratorItem",
+				Path:     []string{"ExternalCode"},
+			},
+		},
+	})
+	if id == "" || len(fb.objects) != 1 {
+		t.Fatalf("expected one list operation activity, got id=%q objects=%d", id, len(fb.objects))
+	}
+
+	activity, ok := fb.objects[0].(*microflows.ActionActivity)
+	if !ok {
+		t.Fatalf("object type = %T, want *microflows.ActionActivity", fb.objects[0])
+	}
+	action, ok := activity.Action.(*microflows.ListOperationAction)
+	if !ok {
+		t.Fatalf("action type = %T, want *microflows.ListOperationAction", activity.Action)
+	}
+	op, ok := action.Operation.(*microflows.FindByAttributeOperation)
+	if !ok {
+		t.Fatalf("operation type = %T, want *microflows.FindByAttributeOperation", action.Operation)
+	}
+	if op.Attribute != "Demo.Item.Code" {
+		t.Fatalf("Attribute = %q, want Demo.Item.Code", op.Attribute)
+	}
+	if op.Expression != "$IteratorItem/ExternalCode" {
+		t.Fatalf("Expression = %q, want $IteratorItem/ExternalCode", op.Expression)
+	}
+}
+
 func TestCallMicroflowUnknownResultTypeStillDeclaresVariable(t *testing.T) {
 	fb := &flowBuilder{
 		varTypes:     map[string]string{"Result": "Old.ModuleEntity"},

--- a/mdl/executor/bugfix_regression_test.go
+++ b/mdl/executor/bugfix_regression_test.go
@@ -743,6 +743,47 @@ func TestListFindAttributeEqualsExpressionUsesAttributeOperation(t *testing.T) {
 	}
 }
 
+func TestListFindUnknownListTypeFallsBackToExpressionOperation(t *testing.T) {
+	fb := &flowBuilder{
+		posX:    100,
+		posY:    100,
+		spacing: HorizontalSpacing,
+	}
+
+	id := fb.addListOperationAction(&ast.ListOperationStmt{
+		OutputVariable: "ExistingItem",
+		Operation:      ast.ListOpFind,
+		InputVariable:  "Items",
+		Condition: &ast.BinaryExpr{
+			Left:     &ast.IdentifierExpr{Name: "Code"},
+			Operator: "=",
+			Right:    &ast.LiteralExpr{Kind: ast.LiteralString, Value: "A"},
+		},
+	})
+	if id == "" || len(fb.objects) != 1 {
+		t.Fatalf("expected one list operation activity, got id=%q objects=%d", id, len(fb.objects))
+	}
+
+	activity, ok := fb.objects[0].(*microflows.ActionActivity)
+	if !ok {
+		t.Fatalf("object type = %T, want *microflows.ActionActivity", fb.objects[0])
+	}
+	action, ok := activity.Action.(*microflows.ListOperationAction)
+	if !ok {
+		t.Fatalf("action type = %T, want *microflows.ListOperationAction", activity.Action)
+	}
+	if _, ok := action.Operation.(*microflows.FindByAttributeOperation); ok {
+		t.Fatal("expected expression fallback, got *microflows.FindByAttributeOperation")
+	}
+	op, ok := action.Operation.(*microflows.FindOperation)
+	if !ok {
+		t.Fatalf("operation type = %T, want *microflows.FindOperation", action.Operation)
+	}
+	if op.Expression == "" {
+		t.Fatal("expected expression fallback to preserve the condition")
+	}
+}
+
 func TestCallMicroflowUnknownResultTypeStillDeclaresVariable(t *testing.T) {
 	fb := &flowBuilder{
 		varTypes:     map[string]string{"Result": "Old.ModuleEntity"},

--- a/mdl/executor/cmd_microflows_builder_actions.go
+++ b/mdl/executor/cmd_microflows_builder_actions.go
@@ -494,16 +494,24 @@ func (fb *flowBuilder) addListOperationAction(s *ast.ListOperationStmt) model.ID
 			ListVariable: s.InputVariable,
 		}
 	case ast.ListOpFind:
-		operation = &microflows.FindOperation{
-			BaseElement:  model.BaseElement{ID: model.ID(types.GenerateID())},
-			ListVariable: s.InputVariable,
-			Expression:   fb.exprToString(s.Condition),
+		if op := fb.listAttributeOperation(s, false); op != nil {
+			operation = op
+		} else {
+			operation = &microflows.FindOperation{
+				BaseElement:  model.BaseElement{ID: model.ID(types.GenerateID())},
+				ListVariable: s.InputVariable,
+				Expression:   fb.exprToString(s.Condition),
+			}
 		}
 	case ast.ListOpFilter:
-		operation = &microflows.FilterOperation{
-			BaseElement:  model.BaseElement{ID: model.ID(types.GenerateID())},
-			ListVariable: s.InputVariable,
-			Expression:   fb.exprToString(s.Condition),
+		if op := fb.listAttributeOperation(s, true); op != nil {
+			operation = op
+		} else {
+			operation = &microflows.FilterOperation{
+				BaseElement:  model.BaseElement{ID: model.ID(types.GenerateID())},
+				ListVariable: s.InputVariable,
+				Expression:   fb.exprToString(s.Condition),
+			}
 		}
 	case ast.ListOpSort:
 		// Resolve entity type from input variable for qualified attribute names
@@ -623,6 +631,62 @@ func (fb *flowBuilder) addListOperationAction(s *ast.ListOperationStmt) model.ID
 	fb.objects = append(fb.objects, activity)
 	fb.posX += fb.spacing
 	return activity.ID
+}
+
+func (fb *flowBuilder) listAttributeOperation(s *ast.ListOperationStmt, filter bool) microflows.ListOperation {
+	binary, ok := s.Condition.(*ast.BinaryExpr)
+	if !ok || binary.Operator != "=" {
+		return nil
+	}
+	fieldName, ok := listOperationFieldName(binary.Left)
+	if !ok || fieldName == "" {
+		return nil
+	}
+	expression := fb.exprToString(binary.Right)
+	if expression == "" {
+		return nil
+	}
+
+	attributeName, associationName := fb.resolveListOperationMember(s.InputVariable, fieldName)
+	if filter {
+		return &microflows.FilterByAttributeOperation{
+			BaseElement:  model.BaseElement{ID: model.ID(types.GenerateID())},
+			ListVariable: s.InputVariable,
+			Attribute:    attributeName,
+			Association:  associationName,
+			Expression:   expression,
+		}
+	}
+	return &microflows.FindByAttributeOperation{
+		BaseElement:  model.BaseElement{ID: model.ID(types.GenerateID())},
+		ListVariable: s.InputVariable,
+		Attribute:    attributeName,
+		Association:  associationName,
+		Expression:   expression,
+	}
+}
+
+func listOperationFieldName(expr ast.Expression) (string, bool) {
+	switch e := expr.(type) {
+	case *ast.IdentifierExpr:
+		return e.Name, true
+	case *ast.QualifiedNameExpr:
+		return e.QualifiedName.String(), true
+	default:
+		return "", false
+	}
+}
+
+func (fb *flowBuilder) resolveListOperationMember(listVariable, memberName string) (attributeName, associationName string) {
+	entityQN := ""
+	if fb.varTypes != nil {
+		if listType := fb.varTypes[listVariable]; strings.HasPrefix(listType, "List of ") {
+			entityQN = strings.TrimPrefix(listType, "List of ")
+		}
+	}
+	memberChange := &microflows.MemberChange{}
+	fb.resolveMemberChange(memberChange, memberName, entityQN)
+	return memberChange.AttributeQualifiedName, memberChange.AssociationQualifiedName
 }
 
 // addAggregateListAction creates aggregate operations like COUNT, SUM, AVERAGE, etc.

--- a/mdl/executor/cmd_microflows_builder_actions.go
+++ b/mdl/executor/cmd_microflows_builder_actions.go
@@ -648,6 +648,9 @@ func (fb *flowBuilder) listAttributeOperation(s *ast.ListOperationStmt, filter b
 	}
 
 	attributeName, associationName := fb.resolveListOperationMember(s.InputVariable, fieldName)
+	if associationName == "" && !strings.Contains(attributeName, ".") {
+		return nil
+	}
 	if filter {
 		return &microflows.FilterByAttributeOperation{
 			BaseElement:  model.BaseElement{ID: model.ID(types.GenerateID())},
@@ -684,6 +687,8 @@ func (fb *flowBuilder) resolveListOperationMember(listVariable, memberName strin
 			entityQN = strings.TrimPrefix(listType, "List of ")
 		}
 	}
+	// Reuse the member-change resolver so list operations follow the same
+	// attribute-vs-association qualification rules as change-object members.
 	memberChange := &microflows.MemberChange{}
 	fb.resolveMemberChange(memberChange, memberName, entityQN)
 	return memberChange.AttributeQualifiedName, memberChange.AssociationQualifiedName

--- a/sdk/mpr/writer_listoperation_test.go
+++ b/sdk/mpr/writer_listoperation_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package mpr
+
+import (
+	"testing"
+
+	"github.com/mendixlabs/mxcli/model"
+	"github.com/mendixlabs/mxcli/sdk/microflows"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestSerializeListOperation_FindByAttribute(t *testing.T) {
+	doc := serializeListOperation(&microflows.FindByAttributeOperation{
+		BaseElement:  model.BaseElement{ID: "operation-id"},
+		ListVariable: "Items",
+		Attribute:    "Demo.Item.Code",
+		Expression:   "$IteratorItem/ExternalCode",
+	})
+	fields := listOperationDocMap(doc)
+
+	if got := fields["$Type"]; got != "Microflows$Find" {
+		t.Fatalf("$Type = %v, want Microflows$Find", got)
+	}
+	if got := fields["Attribute"]; got != "Demo.Item.Code" {
+		t.Fatalf("Attribute = %v, want Demo.Item.Code", got)
+	}
+	if got := fields["Expression"]; got != "$IteratorItem/ExternalCode" {
+		t.Fatalf("Expression = %v, want $IteratorItem/ExternalCode", got)
+	}
+	if got := fields["ListName"]; got != "Items" {
+		t.Fatalf("ListName = %v, want Items", got)
+	}
+}
+
+func TestSerializeListOperation_FilterByAssociation(t *testing.T) {
+	doc := serializeListOperation(&microflows.FilterByAttributeOperation{
+		BaseElement:  model.BaseElement{ID: "operation-id"},
+		ListVariable: "Items",
+		Association:  "Demo.Item_Category",
+		Expression:   "$Category",
+	})
+	fields := listOperationDocMap(doc)
+
+	if got := fields["$Type"]; got != "Microflows$Filter" {
+		t.Fatalf("$Type = %v, want Microflows$Filter", got)
+	}
+	if got := fields["Association"]; got != "Demo.Item_Category" {
+		t.Fatalf("Association = %v, want Demo.Item_Category", got)
+	}
+	if got := fields["Expression"]; got != "$Category" {
+		t.Fatalf("Expression = %v, want $Category", got)
+	}
+}
+
+func listOperationDocMap(doc bson.D) map[string]any {
+	fields := make(map[string]any, len(doc))
+	for _, elem := range doc {
+		fields[elem.Key] = elem.Value
+	}
+	return fields
+}

--- a/sdk/mpr/writer_microflow_actions.go
+++ b/sdk/mpr/writer_microflow_actions.go
@@ -969,6 +969,24 @@ func serializeListOperation(op microflows.ListOperation) bson.D {
 			{Key: "Expression", Value: o.Expression},
 			{Key: "ListName", Value: o.ListVariable}, // storageName: ListName
 		}
+	case *microflows.FindByAttributeOperation:
+		return bson.D{
+			{Key: "$ID", Value: idToBsonBinary(string(o.ID))},
+			{Key: "$Type", Value: "Microflows$Find"},
+			{Key: "Association", Value: o.Association},
+			{Key: "Attribute", Value: o.Attribute},
+			{Key: "Expression", Value: o.Expression},
+			{Key: "ListName", Value: o.ListVariable},
+		}
+	case *microflows.FilterByAttributeOperation:
+		return bson.D{
+			{Key: "$ID", Value: idToBsonBinary(string(o.ID))},
+			{Key: "$Type", Value: "Microflows$Filter"},
+			{Key: "Association", Value: o.Association},
+			{Key: "Attribute", Value: o.Attribute},
+			{Key: "Expression", Value: o.Expression},
+			{Key: "ListName", Value: o.ListVariable},
+		}
 	case *microflows.SortOperation:
 		// Build sorting items
 		sortings := bson.A{int32(3)} // Array with items marker


### PR DESCRIPTION
## Summary

- builds `find/filter($List, Attribute = expression)` as attribute-based list operations when possible
- resolves the left-hand member to an attribute or association using the input list type
- serializes `FindByAttributeOperation` / `FilterByAttributeOperation` to `Microflows$Find` / `Microflows$Filter`
- adds builder and writer regression tests with generic model names

## Why

The parser and formatter already know about attribute-based list operations, but `mxcli exec` rebuilt them as expression-based operations. That can produce an MPR that is textually stable but fails Studio Pro validation with CE0117 on the list operation activity.

## Validation

- `make build`
- `make lint-go`
- `make test`

Closes #343.
Related to #332.