### PR TITLE
fix: preserve manual while-true loop roundtrips

### DIFF
--- a/mdl-examples/bug-tests/350-manual-while-true-loop-roundtrip.mdl
+++ b/mdl-examples/bug-tests/350-manual-while-true-loop-roundtrip.mdl
@@ -1,0 +1,62 @@
+-- ============================================================================
+-- Bug #350: Manual `while true` retry-loop roundtrip
+-- ============================================================================
+--
+-- Symptom (before fix):
+--   Studio Pro projects with manual retry loops authored as
+--     while true
+--     begin
+--       <work>
+--       if <done> then return ...; end if;
+--       continue;
+--     end while;
+--   could be described correctly, but `mxcli exec` rebuilt the same MDL
+--   into either a `LoopedActivity` (collection-style loop) or a flow
+--   with a synthetic fallthrough `EndEvent`. The resulting MPR diverged
+--   from the original — a back-edge merge expected by Studio Pro was
+--   missing — and `mx check` could fail or the model's runtime semantics
+--   could change silently.
+--
+-- Root cause:
+--   The builder accepted `while`, `break`, `continue` syntax but never
+--   materialized BreakEvent/ContinueEvent objects. `continue` in a
+--   manual `while true` body was treated as plain fallthrough.
+--
+-- After fix:
+--   - `BreakEvent` and `ContinueEvent` objects are produced for break/continue.
+--   - Both are treated as terminal branch statements for control-flow analysis.
+--   - Manual `while true` bodies that need a graph-level back-edge are
+--     built as an `ExclusiveMerge` loop header.
+--   - `continue` inside that manual loop routes back to the merge instead
+--     of producing a standalone `ContinueEvent`.
+--
+-- Usage:
+--   mxcli exec mdl-examples/bug-tests/350-manual-while-true-loop-roundtrip.mdl -p app.mpr
+--   mxcli -p app.mpr -c "describe microflow BugTest350.MF_ManualRetryLoop"
+--   `mx check` against the resulting MPR must report 0 errors.
+-- ============================================================================
+
+create module BugTest350;
+
+create entity BugTest350.Item (
+  IsDone : boolean
+);
+/
+
+-- Manual while-true retry loop. The graph rebuild must use an
+-- ExclusiveMerge back-edge — not a LoopedActivity and not a fallthrough
+-- EndEvent — and the `continue` must route to that merge.
+create microflow BugTest350.MF_ManualRetryLoop (
+  $Item: BugTest350.Item
+)
+returns boolean as $Done
+begin
+  while true
+  begin
+    if $Item/IsDone then
+      return true;
+    end if;
+    continue;
+  end while;
+end;
+/

--- a/mdl/executor/cmd_microflows_builder.go
+++ b/mdl/executor/cmd_microflows_builder.go
@@ -45,7 +45,8 @@ type flowBuilder struct {
 	// previousStmtAnchor holds the Anchor annotation of the statement that
 	// just emitted an activity, so the next flow's OriginConnectionIndex can
 	// be overridden by the user. Cleared after each flow is created.
-	previousStmtAnchor *ast.FlowAnchors
+	previousStmtAnchor   *ast.FlowAnchors
+	manualLoopBackTarget model.ID
 }
 
 // addError records a validation error during flow building.

--- a/mdl/executor/cmd_microflows_builder_control.go
+++ b/mdl/executor/cmd_microflows_builder_control.go
@@ -439,9 +439,150 @@ func (fb *flowBuilder) addLoopStatement(s *ast.LoopStmt) model.ID {
 	return loop.ID
 }
 
+func isManualWhileTrueCandidate(s *ast.WhileStmt) bool {
+	if s == nil || containsBreakForCurrentLoop(s.Body) || (!containsContinueStmt(s.Body) && !containsTerminalStmt(s.Body)) {
+		return false
+	}
+	lit, ok := s.Condition.(*ast.LiteralExpr)
+	if !ok || lit.Kind != ast.LiteralBoolean {
+		return false
+	}
+	value, ok := lit.Value.(bool)
+	return ok && value
+}
+
+func containsBreakForCurrentLoop(stmts []ast.MicroflowStatement) bool {
+	for _, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *ast.BreakStmt:
+			return true
+		case *ast.IfStmt:
+			if containsBreakForCurrentLoop(s.ThenBody) || containsBreakForCurrentLoop(s.ElseBody) {
+				return true
+			}
+		case *ast.LoopStmt, *ast.WhileStmt:
+			// A break inside a nested loop exits that nested loop, not this
+			// manual while-true back-edge.
+			continue
+		}
+	}
+	return false
+}
+
+func containsContinueStmt(stmts []ast.MicroflowStatement) bool {
+	for _, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *ast.ContinueStmt:
+			return true
+		case *ast.IfStmt:
+			if containsContinueStmt(s.ThenBody) || containsContinueStmt(s.ElseBody) {
+				return true
+			}
+		case *ast.LoopStmt:
+			if containsContinueStmt(s.Body) {
+				return true
+			}
+		case *ast.WhileStmt:
+			if containsContinueStmt(s.Body) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (fb *flowBuilder) addManualWhileTrueStatement(s *ast.WhileStmt) model.ID {
+	mergeX := fb.posX
+	mergeY := fb.posY
+	if s.Annotations != nil && s.Annotations.Position != nil {
+		mergeX = s.Annotations.Position.X
+		mergeY = s.Annotations.Position.Y
+	}
+
+	merge := &microflows.ExclusiveMerge{
+		BaseMicroflowObject: microflows.BaseMicroflowObject{
+			BaseElement: model.BaseElement{ID: model.ID(types.GenerateID())},
+			Position:    model.Point{X: mergeX, Y: mergeY},
+			Size:        model.Size{Width: MergeSize, Height: MergeSize},
+		},
+	}
+	fb.objects = append(fb.objects, merge)
+	if fb.pendingAnnotations != nil {
+		fb.applyAnnotations(merge.ID, fb.pendingAnnotations)
+		fb.pendingAnnotations = nil
+	}
+
+	savedBackTarget := fb.manualLoopBackTarget
+	fb.manualLoopBackTarget = merge.ID
+	defer func() { fb.manualLoopBackTarget = savedBackTarget }()
+
+	fb.posX = mergeX + MergeSize + HorizontalSpacing/2
+	fb.posY = mergeY
+
+	lastBodyID := merge.ID
+	var pendingBodyCase string
+	var pendingBodyAnchor *ast.FlowAnchors
+	var prevBodyAnchor *ast.FlowAnchors
+	for _, stmt := range s.Body {
+		thisAnchor := stmtOwnAnchor(stmt)
+		actID := fb.addStatement(stmt)
+		if actID == "" {
+			continue
+		}
+		if fb.pendingAnnotations != nil {
+			fb.applyAnnotations(actID, fb.pendingAnnotations)
+			fb.pendingAnnotations = nil
+		}
+		if lastBodyID != "" && lastBodyID != actID {
+			var flow *microflows.SequenceFlow
+			if pendingBodyCase != "" {
+				flow = newHorizontalFlowWithCase(lastBodyID, actID, pendingBodyCase)
+				if pendingBodyAnchor != nil {
+					prevBodyAnchor = pendingBodyAnchor
+				}
+				pendingBodyCase = ""
+				pendingBodyAnchor = nil
+			} else {
+				flow = newHorizontalFlow(lastBodyID, actID)
+			}
+			applyUserAnchors(flow, prevBodyAnchor, thisAnchor)
+			fb.flows = append(fb.flows, flow)
+		}
+		prevBodyAnchor = thisAnchor
+		if fb.nextConnectionPoint != "" {
+			lastBodyID = fb.nextConnectionPoint
+			fb.nextConnectionPoint = ""
+			pendingBodyCase = fb.nextFlowCase
+			fb.nextFlowCase = ""
+			pendingBodyAnchor = fb.nextFlowAnchor
+			fb.nextFlowAnchor = nil
+		} else {
+			lastBodyID = actID
+		}
+	}
+
+	if lastBodyID != "" && lastBodyID != merge.ID && !lastStmtIsReturn(s.Body) {
+		var flow *microflows.SequenceFlow
+		if pendingBodyCase != "" {
+			flow = newHorizontalFlowWithCase(lastBodyID, merge.ID, pendingBodyCase)
+		} else {
+			flow = newHorizontalFlow(lastBodyID, merge.ID)
+		}
+		applyUserAnchors(flow, pendingBodyAnchor, pendingBodyAnchor)
+		fb.flows = append(fb.flows, flow)
+	}
+	fb.endsWithReturn = true
+
+	return merge.ID
+}
+
 // addWhileStatement creates a WHILE loop using LoopedActivity with WhileLoopCondition.
 // Layout matches addLoopStatement but without iterator icon space.
 func (fb *flowBuilder) addWhileStatement(s *ast.WhileStmt) model.ID {
+	if isManualWhileTrueCandidate(s) {
+		return fb.addManualWhileTrueStatement(s)
+	}
+
 	// Snapshot & clear this WHILE's own annotations so the body's recursive
 	// addStatement calls can't consume them (see addLoopStatement).
 	savedWhileAnnotations := fb.pendingAnnotations
@@ -525,4 +666,34 @@ func (fb *flowBuilder) addWhileStatement(s *ast.WhileStmt) model.ID {
 	fb.posX = loopLeftX + loopWidth + HorizontalSpacing
 
 	return loop.ID
+}
+
+func (fb *flowBuilder) addBreakEvent() model.ID {
+	event := &microflows.BreakEvent{
+		BaseMicroflowObject: microflows.BaseMicroflowObject{
+			BaseElement: model.BaseElement{ID: model.ID(types.GenerateID())},
+			Position:    model.Point{X: fb.posX, Y: fb.posY},
+			Size:        model.Size{Width: EventSize, Height: EventSize},
+		},
+	}
+	fb.objects = append(fb.objects, event)
+	fb.posX += fb.spacing
+	return event.ID
+}
+
+func (fb *flowBuilder) addContinueEvent() model.ID {
+	if fb.manualLoopBackTarget != "" {
+		return fb.manualLoopBackTarget
+	}
+
+	event := &microflows.ContinueEvent{
+		BaseMicroflowObject: microflows.BaseMicroflowObject{
+			BaseElement: model.BaseElement{ID: model.ID(types.GenerateID())},
+			Position:    model.Point{X: fb.posX, Y: fb.posY},
+			Size:        model.Size{Width: EventSize, Height: EventSize},
+		},
+	}
+	fb.objects = append(fb.objects, event)
+	fb.posX += fb.spacing
+	return event.ID
 }

--- a/mdl/executor/cmd_microflows_builder_flows.go
+++ b/mdl/executor/cmd_microflows_builder_flows.go
@@ -192,12 +192,13 @@ func applyUserAnchors(flow *microflows.SequenceFlow, origin *ast.FlowAnchors, de
 }
 
 // lastStmtIsReturn reports whether execution of a body is guaranteed to terminate
-// (via RETURN or RAISE ERROR) on every path — i.e. control can never fall off the
-// end of the body into the parent flow.
+// (via RETURN, RAISE ERROR, BREAK, or CONTINUE) on every path — i.e. control can
+// never fall off the end of the body into the parent flow.
 //
-// Terminal statements: ReturnStmt, RaiseErrorStmt. An IfStmt is terminal iff it
-// has an ELSE and both branches are terminal (recursively). A LoopStmt is never
-// terminal — BREAK can exit the loop even if the body returns.
+// Terminal statements: ReturnStmt, RaiseErrorStmt, BreakStmt, ContinueStmt. An
+// IfStmt is terminal iff it has an ELSE and both branches are terminal
+// (recursively). A LoopStmt is never terminal — BREAK can exit the loop even if
+// the body returns.
 //
 // Naming kept for history; the predicate is really "last stmt is a guaranteed
 // terminator". Missing this case causes the outer IF to emit a dangling
@@ -216,12 +217,40 @@ func isTerminalStmt(stmt ast.MicroflowStatement) bool {
 		return true
 	case *ast.RaiseErrorStmt:
 		return true
+	case *ast.BreakStmt:
+		return true
+	case *ast.ContinueStmt:
+		return true
 	case *ast.IfStmt:
 		if len(s.ElseBody) == 0 {
 			return false
 		}
 		return lastStmtIsReturn(s.ThenBody) && lastStmtIsReturn(s.ElseBody)
+	case *ast.WhileStmt:
+		return isManualWhileTrueCandidate(s)
 	default:
 		return false
 	}
+}
+
+func containsTerminalStmt(stmts []ast.MicroflowStatement) bool {
+	for _, stmt := range stmts {
+		switch s := stmt.(type) {
+		case *ast.ReturnStmt, *ast.RaiseErrorStmt:
+			return true
+		case *ast.IfStmt:
+			if containsTerminalStmt(s.ThenBody) || containsTerminalStmt(s.ElseBody) {
+				return true
+			}
+		case *ast.LoopStmt:
+			if containsTerminalStmt(s.Body) {
+				return true
+			}
+		case *ast.WhileStmt:
+			if containsTerminalStmt(s.Body) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/mdl/executor/cmd_microflows_builder_graph.go
+++ b/mdl/executor/cmd_microflows_builder_graph.go
@@ -188,6 +188,10 @@ func (fb *flowBuilder) addStatement(stmt ast.MicroflowStatement) model.ID {
 		return fb.addEndEventWithReturn(s)
 	case *ast.RaiseErrorStmt:
 		return fb.addErrorEvent()
+	case *ast.BreakStmt:
+		return fb.addBreakEvent()
+	case *ast.ContinueStmt:
+		return fb.addContinueEvent()
 	case *ast.LogStmt:
 		return fb.addLogMessageAction(s)
 	case *ast.CreateObjectStmt:

--- a/mdl/executor/cmd_microflows_builder_terminal_test.go
+++ b/mdl/executor/cmd_microflows_builder_terminal_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/mendixlabs/mxcli/mdl/ast"
+	"github.com/mendixlabs/mxcli/sdk/microflows"
 )
 
 func TestLastStmtIsReturn_EmptyBody(t *testing.T) {
@@ -25,6 +26,14 @@ func TestLastStmtIsReturn_RaiseError(t *testing.T) {
 	body := []ast.MicroflowStatement{&ast.RaiseErrorStmt{}}
 	if !lastStmtIsReturn(body) {
 		t.Error("body ending in RaiseErrorStmt must be terminal")
+	}
+}
+
+func TestLastStmtIsReturn_BreakAndContinue(t *testing.T) {
+	for _, stmt := range []ast.MicroflowStatement{&ast.BreakStmt{}, &ast.ContinueStmt{}} {
+		if !lastStmtIsReturn([]ast.MicroflowStatement{stmt}) {
+			t.Errorf("body ending in %T must be terminal", stmt)
+		}
 	}
 }
 
@@ -88,6 +97,18 @@ func TestLastStmtIsReturn_RaiseErrorMixed_Terminal(t *testing.T) {
 	}
 }
 
+func TestLastStmtIsReturn_IfBreakContinueBranches_Terminal(t *testing.T) {
+	body := []ast.MicroflowStatement{
+		&ast.IfStmt{
+			ThenBody: []ast.MicroflowStatement{&ast.ContinueStmt{}},
+			ElseBody: []ast.MicroflowStatement{&ast.BreakStmt{}},
+		},
+	}
+	if !lastStmtIsReturn(body) {
+		t.Error("IF/ELSE with continue on one side and break on the other must be terminal")
+	}
+}
+
 func TestLastStmtIsReturn_LoopNotTerminal(t *testing.T) {
 	// A LOOP whose body only returns is still non-terminal — BREAK can exit.
 	body := []ast.MicroflowStatement{
@@ -95,5 +116,134 @@ func TestLastStmtIsReturn_LoopNotTerminal(t *testing.T) {
 	}
 	if lastStmtIsReturn(body) {
 		t.Error("LOOP must never be terminal (BREAK path)")
+	}
+}
+
+func TestBuildFlowGraph_LoopIfPreservesBreakAndContinue(t *testing.T) {
+	body := []ast.MicroflowStatement{
+		&ast.LoopStmt{
+			LoopVariable: "Item",
+			ListVariable: "Items",
+			Body: []ast.MicroflowStatement{
+				&ast.IfStmt{
+					Condition: &ast.VariableExpr{Name: "Changed"},
+					ThenBody:  []ast.MicroflowStatement{&ast.ContinueStmt{}},
+					ElseBody:  []ast.MicroflowStatement{&ast.BreakStmt{}},
+				},
+			},
+		},
+	}
+
+	fb := &flowBuilder{
+		posX:         100,
+		posY:         100,
+		spacing:      HorizontalSpacing,
+		varTypes:     map[string]string{"Items": "List of MyModule.Item"},
+		declaredVars: map[string]string{"Changed": "Boolean"},
+		measurer:     &layoutMeasurer{},
+	}
+	oc := fb.buildFlowGraph(body, nil)
+
+	var loop *microflows.LoopedActivity
+	for _, obj := range oc.Objects {
+		if l, ok := obj.(*microflows.LoopedActivity); ok {
+			loop = l
+			break
+		}
+	}
+	if loop == nil || loop.ObjectCollection == nil {
+		t.Fatal("expected loop with object collection")
+	}
+
+	var hasBreak, hasContinue bool
+	for _, obj := range loop.ObjectCollection.Objects {
+		switch obj.(type) {
+		case *microflows.BreakEvent:
+			hasBreak = true
+		case *microflows.ContinueEvent:
+			hasContinue = true
+		}
+	}
+	if !hasBreak || !hasContinue {
+		t.Fatalf("expected break and continue events in loop body, got break=%v continue=%v", hasBreak, hasContinue)
+	}
+}
+
+func TestBuildFlowGraph_ManualWhileTrueContinueUsesBackEdgeMerge(t *testing.T) {
+	body := []ast.MicroflowStatement{
+		&ast.WhileStmt{
+			Condition: &ast.LiteralExpr{Kind: ast.LiteralBoolean, Value: true},
+			Body: []ast.MicroflowStatement{
+				&ast.LogStmt{Level: ast.LogInfo, Message: &ast.LiteralExpr{Kind: ast.LiteralString, Value: "retry"}},
+				&ast.ContinueStmt{},
+			},
+		},
+	}
+
+	fb := &flowBuilder{
+		posX:     100,
+		posY:     100,
+		spacing:  HorizontalSpacing,
+		measurer: &layoutMeasurer{},
+	}
+	oc := fb.buildFlowGraph(body, nil)
+
+	var merge *microflows.ExclusiveMerge
+	for _, obj := range oc.Objects {
+		switch o := obj.(type) {
+		case *microflows.LoopedActivity:
+			t.Fatal("manual while true with continue must not be rebuilt as LoopedActivity")
+		case *microflows.ContinueEvent:
+			t.Fatal("manual while true back-edge must not emit ContinueEvent outside a LoopedActivity")
+		case *microflows.ExclusiveMerge:
+			merge = o
+		}
+	}
+	if merge == nil {
+		t.Fatal("expected manual loop header ExclusiveMerge")
+	}
+
+	var backEdges int
+	for _, flow := range oc.Flows {
+		if flow.DestinationID == merge.ID {
+			backEdges++
+		}
+	}
+	if backEdges == 0 {
+		t.Fatal("expected continue branch to connect back to the manual-loop merge")
+	}
+}
+
+func TestBuildFlowGraph_ManualWhileTrueTerminalDoesNotAddFallthroughEnd(t *testing.T) {
+	body := []ast.MicroflowStatement{
+		&ast.WhileStmt{
+			Condition: &ast.LiteralExpr{Kind: ast.LiteralBoolean, Value: true},
+			Body: []ast.MicroflowStatement{
+				&ast.IfStmt{
+					Condition: &ast.VariableExpr{Name: "Done"},
+					ThenBody:  []ast.MicroflowStatement{&ast.ReturnStmt{Value: &ast.LiteralExpr{Kind: ast.LiteralBoolean, Value: true}}},
+				},
+				&ast.ContinueStmt{},
+			},
+		},
+	}
+
+	fb := &flowBuilder{
+		posX:         100,
+		posY:         100,
+		spacing:      HorizontalSpacing,
+		declaredVars: map[string]string{"Done": "Boolean"},
+		measurer:     &layoutMeasurer{},
+	}
+	oc := fb.buildFlowGraph(body, &ast.MicroflowReturnType{Type: ast.DataType{Kind: ast.TypeBoolean}})
+
+	for _, obj := range oc.Objects {
+		end, ok := obj.(*microflows.EndEvent)
+		if !ok {
+			continue
+		}
+		if end.ReturnValue == "" {
+			t.Fatal("manual while true ending in continue must not add a fallthrough EndEvent without return value")
+		}
 	}
 }

--- a/mdl/executor/cmd_microflows_show_helpers.go
+++ b/mdl/executor/cmd_microflows_show_helpers.go
@@ -468,6 +468,16 @@ func traverseFlow(
 		if isMergePairedWithSplit(currentID, splitMergeMap) {
 			return
 		}
+		if mergeHasLoopBackEdge(currentID, flowsByOrigin) {
+			visited[currentID] = true
+			*lines = append(*lines, strings.Repeat("  ", indent)+"while true")
+			*lines = append(*lines, strings.Repeat("  ", indent)+"begin")
+			for _, flow := range findNormalFlows(flowsByOrigin[currentID]) {
+				traverseFlowUntilMerge(ctx, flow.DestinationID, currentID, activityMap, flowsByOrigin, flowsByDest, splitMergeMap, visited, entityNames, microflowNames, lines, indent+1, sourceMap, headerLineCount, annotationsByTarget)
+			}
+			*lines = append(*lines, strings.Repeat("  ", indent)+"end while;")
+			return
+		}
 		visited[currentID] = true
 		for _, flow := range flowsByOrigin[currentID] {
 			traverseFlow(ctx, flow.DestinationID, activityMap, flowsByOrigin, flowsByDest, splitMergeMap, visited, entityNames, microflowNames, lines, indent, sourceMap, headerLineCount, annotationsByTarget)
@@ -904,6 +914,31 @@ func emitLoopBody(
 func isMergePairedWithSplit(mergeID model.ID, splitMergeMap map[model.ID]model.ID) bool {
 	for _, v := range splitMergeMap {
 		if v == mergeID {
+			return true
+		}
+	}
+	return false
+}
+
+func mergeHasLoopBackEdge(mergeID model.ID, flowsByOrigin map[model.ID][]*microflows.SequenceFlow) bool {
+	for _, flow := range findNormalFlows(flowsByOrigin[mergeID]) {
+		if reachesObject(flow.DestinationID, mergeID, flowsByOrigin, map[model.ID]bool{}) {
+			return true
+		}
+	}
+	return false
+}
+
+func reachesObject(currentID, targetID model.ID, flowsByOrigin map[model.ID][]*microflows.SequenceFlow, visited map[model.ID]bool) bool {
+	if currentID == "" || visited[currentID] {
+		return false
+	}
+	if currentID == targetID {
+		return true
+	}
+	visited[currentID] = true
+	for _, flow := range findNormalFlows(flowsByOrigin[currentID]) {
+		if reachesObject(flow.DestinationID, targetID, flowsByOrigin, visited) {
 			return true
 		}
 	}

--- a/mdl/executor/cmd_microflows_unpaired_merge_test.go
+++ b/mdl/executor/cmd_microflows_unpaired_merge_test.go
@@ -207,6 +207,9 @@ func TestTraverseFlow_ManualRetryLoopPatternEmitsEverything(t *testing.T) {
 	e.traverseFlow(mkID("start"), activityMap, flowsByOrigin, nil, visited, nil, nil, &lines, 0, nil, 0, nil)
 
 	out := strings.Join(lines, "\n")
+	if !strings.Contains(out, "while true") || !strings.Contains(out, "end while;") {
+		t.Errorf("manual retry loop must be emitted as a while-true block so exec rebuilds the back-edge:\n%s", out)
+	}
 	for _, want := range []string{"setup", "call-rest", "if $retry then", "change-retry-count", "delay"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("issue #281: missing %q from describe output:\n%s", want, out)

--- a/mdl/executor/validate_microflow.go
+++ b/mdl/executor/validate_microflow.go
@@ -279,8 +279,22 @@ func bodyReturns(stmts []ast.MicroflowStatement) bool {
 	case *ast.IfStmt:
 		// Both branches must return, and ELSE must be present
 		return len(s.ElseBody) > 0 && bodyReturns(s.ThenBody) && bodyReturns(s.ElseBody)
+	case *ast.WhileStmt:
+		return isUnconditionalTrueWhile(s) && !containsBreakForCurrentLoop(s.Body)
 	}
 	return false
+}
+
+func isUnconditionalTrueWhile(s *ast.WhileStmt) bool {
+	if s == nil {
+		return false
+	}
+	lit, ok := s.Condition.(*ast.LiteralExpr)
+	if !ok || lit.Kind != ast.LiteralBoolean {
+		return false
+	}
+	value, ok := lit.Value.(bool)
+	return ok && value
 }
 
 // checkBranchScoping detects variables declared inside IF/ELSE branches that are

--- a/mdl/executor/validate_microflow_while_test.go
+++ b/mdl/executor/validate_microflow_while_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/mendixlabs/mxcli/mdl/ast"
+)
+
+func TestValidateMicroflow_WhileTrueWithoutBreakDoesNotNeedFallthroughReturn(t *testing.T) {
+	stmt := &ast.CreateMicroflowStmt{
+		Name: ast.QualifiedName{Module: "Sample", Name: "PollUntilDone"},
+		ReturnType: &ast.MicroflowReturnType{
+			Type: ast.DataType{Kind: ast.TypeBoolean},
+		},
+		Body: []ast.MicroflowStatement{
+			&ast.WhileStmt{
+				Condition: &ast.LiteralExpr{Kind: ast.LiteralBoolean, Value: true},
+				Body: []ast.MicroflowStatement{
+					&ast.IfStmt{
+						Condition: &ast.VariableExpr{Name: "Done"},
+						ThenBody: []ast.MicroflowStatement{
+							&ast.ReturnStmt{Value: &ast.LiteralExpr{Kind: ast.LiteralBoolean, Value: true}},
+						},
+					},
+					&ast.LogStmt{Level: ast.LogInfo, Message: &ast.LiteralExpr{Kind: ast.LiteralString, Value: "retry"}},
+				},
+			},
+		},
+	}
+
+	violations := ValidateMicroflow(stmt)
+	for _, violation := range violations {
+		if violation.RuleID == "MDL003" {
+			t.Fatalf("while true without break must not require a fallthrough return: %#v", violation)
+		}
+	}
+}
+
+func TestValidateMicroflow_WhileTrueWithBreakStillNeedsFallthroughReturn(t *testing.T) {
+	stmt := &ast.CreateMicroflowStmt{
+		Name: ast.QualifiedName{Module: "Sample", Name: "MaybeBreak"},
+		ReturnType: &ast.MicroflowReturnType{
+			Type: ast.DataType{Kind: ast.TypeBoolean},
+		},
+		Body: []ast.MicroflowStatement{
+			&ast.WhileStmt{
+				Condition: &ast.LiteralExpr{Kind: ast.LiteralBoolean, Value: true},
+				Body: []ast.MicroflowStatement{
+					&ast.BreakStmt{},
+				},
+			},
+		},
+	}
+
+	violations := ValidateMicroflow(stmt)
+	for _, violation := range violations {
+		if violation.RuleID == "MDL003" {
+			return
+		}
+	}
+	t.Fatalf("expected MDL003 for while true that can break, got %#v", violations)
+}


### PR DESCRIPTION
Closes #350.
Part of #332.

## Summary

This extracts the manual `while true` loop preservation from the audit staging branch into a focused fix.

The builder already accepted `while`, `break`, and `continue` syntax, but it did not materialize break/continue events and it treated `continue` as a normal fallthrough path. For retry-style `while true` loops this could rebuild the flow as a `LoopedActivity` or synthesize an invalid fallthrough `EndEvent`.

## Changes

- Build `BreakEvent` and `ContinueEvent` objects for parsed break/continue statements.
- Treat break/continue as terminal branch statements for control-flow analysis.
- Detect manual `while true` bodies that need a graph-level back-edge and build them as an `ExclusiveMerge` loop header.
- Route `continue` inside that manual loop back to the merge instead of emitting a standalone `ContinueEvent`.

## Validation

- `make build`
- `make lint-go`
- `make test`
