### PR TITLE
fix: preserve compact reverse-association retrieves

### DIFF
--- a/mdl-examples/bug-tests/352-retrieve-compact-reverse-association.mdl
+++ b/mdl-examples/bug-tests/352-retrieve-compact-reverse-association.mdl
@@ -1,0 +1,56 @@
+-- ============================================================================
+-- Bug #352 (part): Compact reverse-association retrieve formatter
+-- ============================================================================
+--
+-- Symptom (before fix):
+--   Some Mendix models store a compact association retrieve as a
+--   `DatabaseRetrieveSource` with a single XPath predicate of the form
+--     [Module.Association = $Variable]
+--   and `Range = All`. When described, the formatter emitted the verbose
+--   shape
+--     retrieve $Domains from Module.Domain
+--       where Module.Domain_Runtime = $Runtime;
+--   On `mxcli exec`, that verbose shape is rebuilt as XPath. Studio Pro
+--   then accepts it but `describe → exec → describe` is no longer a
+--   fixpoint, and tooling that expects the compact form sees drift.
+--
+-- After fix:
+--   When the source is a database retrieve over a single equality
+--   predicate against a known association whose other side matches the
+--   start variable's type, and `Range = All`, the formatter emits the
+--   compact form `retrieve $Out from $Var/Module.Association`.
+--
+-- Usage:
+--   mxcli exec mdl-examples/bug-tests/352-retrieve-compact-reverse-association.mdl -p app.mpr
+--   mxcli -p app.mpr -c "describe microflow BugTest352a.MF_FetchDomains"
+--   The describe output must use the compact `from $Runtime/Mod.Assoc`
+--   form, and `mx check` must report 0 errors.
+-- ============================================================================
+
+create module BugTest352a;
+
+create entity BugTest352a.Runtime (
+  Name : string(100)
+);
+/
+
+create entity BugTest352a.Domain (
+  Name : string(100)
+);
+/
+
+create association BugTest352a.Domain_Runtime
+  from BugTest352a.Domain
+  to BugTest352a.Runtime;
+/
+
+-- Compact reverse-association retrieve. Describe → exec → describe must
+-- preserve the `from $Runtime/BugTest352a.Domain_Runtime` shape.
+create microflow BugTest352a.MF_FetchDomains (
+  $Runtime: BugTest352a.Runtime
+)
+returns list of BugTest352a.Domain as $Domains
+begin
+  retrieve $Domains from $Runtime/BugTest352a.Domain_Runtime;
+end;
+/

--- a/mdl/executor/cmd_microflows_builder_actions.go
+++ b/mdl/executor/cmd_microflows_builder_actions.go
@@ -300,6 +300,8 @@ func (fb *flowBuilder) addRetrieveAction(s *ast.RetrieveStmt) model.ID {
 		}
 
 		if assocInfo != nil && assocInfo.Type == domainmodel.AssociationTypeReference &&
+			assocInfo.Owner != domainmodel.AssociationOwnerBoth &&
+			assocInfo.parentPersistable &&
 			assocInfo.childEntityQN != "" && startVarType == assocInfo.childEntityQN {
 			// Reverse traversal on Reference: child → parent (one-to-many)
 			// Use DatabaseRetrieveSource with XPath to get a list of parent entities
@@ -862,9 +864,12 @@ func resolveMemberChangeFallback(mc *microflows.MemberChange, memberName string,
 
 // assocLookupResult holds resolved association metadata.
 type assocLookupResult struct {
-	Type           domainmodel.AssociationType
-	parentEntityQN string // Qualified name of the parent (FROM/owner) entity
-	childEntityQN  string // Qualified name of the child (TO/referenced) entity
+	Type              domainmodel.AssociationType
+	Owner             domainmodel.AssociationOwner
+	parentEntityQN    string // Qualified name of the parent (FROM/owner) entity
+	childEntityQN     string // Qualified name of the child (TO/referenced) entity
+	parentPersistable bool
+	childPersistable  bool
 }
 
 // lookupAssociation finds an association by module and name, returning its type
@@ -885,16 +890,21 @@ func (fb *flowBuilder) lookupAssociation(moduleName, assocName string) *assocLoo
 
 	// Build entity ID → qualified name map
 	entityNames := make(map[model.ID]string, len(dm.Entities))
+	entityPersistable := make(map[model.ID]bool, len(dm.Entities))
 	for _, e := range dm.Entities {
 		entityNames[e.ID] = moduleName + "." + e.Name
+		entityPersistable[e.ID] = e.Persistable
 	}
 
 	for _, a := range dm.Associations {
 		if a.Name == assocName {
 			return &assocLookupResult{
-				Type:           a.Type,
-				parentEntityQN: entityNames[a.ParentID],
-				childEntityQN:  entityNames[a.ChildID],
+				Type:              a.Type,
+				Owner:             a.Owner,
+				parentEntityQN:    entityNames[a.ParentID],
+				childEntityQN:     entityNames[a.ChildID],
+				parentPersistable: entityPersistable[a.ParentID],
+				childPersistable:  entityPersistable[a.ChildID],
 			}
 		}
 	}

--- a/mdl/executor/cmd_microflows_builder_actions.go
+++ b/mdl/executor/cmd_microflows_builder_actions.go
@@ -329,6 +329,18 @@ func (fb *flowBuilder) addRetrieveAction(s *ast.RetrieveStmt) model.ID {
 						otherEntity = assocInfo.parentEntityQN
 					}
 					fb.varTypes[s.Variable] = otherEntity
+				} else if assocInfo != nil && assocInfo.Type == domainmodel.AssociationTypeReferenceSet {
+					// ReferenceSet traversal returns a list of the entity on the other side,
+					// not a list typed as the association itself.
+					otherEntity := assocInfo.childEntityQN
+					if startVarType == assocInfo.childEntityQN {
+						otherEntity = assocInfo.parentEntityQN
+					}
+					if otherEntity != "" {
+						fb.varTypes[s.Variable] = "List of " + otherEntity
+					} else {
+						fb.varTypes[s.Variable] = "List of " + assocQN
+					}
 				} else {
 					// ReferenceSet or unknown: returns a list
 					fb.varTypes[s.Variable] = "List of " + assocQN

--- a/mdl/executor/cmd_microflows_builder_retrieve_reverse_test.go
+++ b/mdl/executor/cmd_microflows_builder_retrieve_reverse_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/mendixlabs/mxcli/mdl/ast"
+	"github.com/mendixlabs/mxcli/mdl/backend/mock"
+	"github.com/mendixlabs/mxcli/model"
+	"github.com/mendixlabs/mxcli/sdk/domainmodel"
+	"github.com/mendixlabs/mxcli/sdk/microflows"
+)
+
+func TestAddRetrieveAction_ReverseReferenceOwnerBothUsesAssociationSource(t *testing.T) {
+	fb := newRetrieveAssociationFlowBuilder(domainmodel.AssociationOwnerBoth)
+	fb.varTypes["Child"] = "Sample.Child"
+
+	fb.addRetrieveAction(&ast.RetrieveStmt{
+		Variable:      "Parent",
+		StartVariable: "Child",
+		Source:        ast.QualifiedName{Module: "Sample", Name: "Parent_Child"},
+	})
+
+	action := onlyRetrieveAction(t, fb)
+	source, ok := action.Source.(*microflows.AssociationRetrieveSource)
+	if !ok {
+		t.Fatalf("owner-both reverse retrieve source = %T, want AssociationRetrieveSource", action.Source)
+	}
+	if source.StartVariable != "Child" || source.AssociationQualifiedName != "Sample.Parent_Child" {
+		t.Fatalf("association source = %#v", source)
+	}
+	if got := fb.varTypes["Parent"]; got != "Sample.Parent" {
+		t.Fatalf("result var type = %q, want Sample.Parent", got)
+	}
+}
+
+func TestAddRetrieveAction_ReverseReferenceDefaultOwnerUsesDatabaseSource(t *testing.T) {
+	fb := newRetrieveAssociationFlowBuilder(domainmodel.AssociationOwnerDefault)
+	fb.varTypes["Child"] = "Sample.Child"
+
+	fb.addRetrieveAction(&ast.RetrieveStmt{
+		Variable:      "Parents",
+		StartVariable: "Child",
+		Source:        ast.QualifiedName{Module: "Sample", Name: "Parent_Child"},
+	})
+
+	action := onlyRetrieveAction(t, fb)
+	source, ok := action.Source.(*microflows.DatabaseRetrieveSource)
+	if !ok {
+		t.Fatalf("default-owner reverse retrieve source = %T, want DatabaseRetrieveSource", action.Source)
+	}
+	if source.EntityQualifiedName != "Sample.Parent" || source.XPathConstraint != "[Sample.Parent_Child = $Child]" {
+		t.Fatalf("database source = %#v", source)
+	}
+	if got := fb.varTypes["Parents"]; got != "List of Sample.Parent" {
+		t.Fatalf("result var type = %q, want List of Sample.Parent", got)
+	}
+}
+
+func TestAddRetrieveAction_ReverseReferenceNonPersistableParentUsesAssociationSource(t *testing.T) {
+	fb := newRetrieveAssociationFlowBuilderWithPersistability(domainmodel.AssociationOwnerDefault, false, true)
+	fb.varTypes["Child"] = "Sample.Child"
+
+	fb.addRetrieveAction(&ast.RetrieveStmt{
+		Variable:      "Parents",
+		StartVariable: "Child",
+		Source:        ast.QualifiedName{Module: "Sample", Name: "Parent_Child"},
+	})
+
+	action := onlyRetrieveAction(t, fb)
+	source, ok := action.Source.(*microflows.AssociationRetrieveSource)
+	if !ok {
+		t.Fatalf("non-persistable reverse retrieve source = %T, want AssociationRetrieveSource", action.Source)
+	}
+	if source.StartVariable != "Child" || source.AssociationQualifiedName != "Sample.Parent_Child" {
+		t.Fatalf("association source = %#v", source)
+	}
+	if got := fb.varTypes["Parents"]; got != "Sample.Parent" {
+		t.Fatalf("result var type = %q, want Sample.Parent", got)
+	}
+}
+
+func newRetrieveAssociationFlowBuilder(owner domainmodel.AssociationOwner) *flowBuilder {
+	return newRetrieveAssociationFlowBuilderWithPersistability(owner, true, true)
+}
+
+func newRetrieveAssociationFlowBuilderWithPersistability(owner domainmodel.AssociationOwner, parentPersistable, childPersistable bool) *flowBuilder {
+	moduleID := model.ID("sample-module")
+	parentID := model.ID("parent-entity")
+	childID := model.ID("child-entity")
+	return &flowBuilder{
+		varTypes: map[string]string{},
+		backend: &mock.MockBackend{
+			GetModuleByNameFunc: func(name string) (*model.Module, error) {
+				if name != "Sample" {
+					return nil, nil
+				}
+				return &model.Module{BaseElement: model.BaseElement{ID: moduleID}, Name: name}, nil
+			},
+			GetDomainModelFunc: func(id model.ID) (*domainmodel.DomainModel, error) {
+				if id != moduleID {
+					return nil, nil
+				}
+				return &domainmodel.DomainModel{
+					ContainerID: moduleID,
+					Entities: []*domainmodel.Entity{
+						{BaseElement: model.BaseElement{ID: parentID}, Name: "Parent", Persistable: parentPersistable},
+						{BaseElement: model.BaseElement{ID: childID}, Name: "Child", Persistable: childPersistable},
+					},
+					Associations: []*domainmodel.Association{
+						{
+							Name:     "Parent_Child",
+							ParentID: parentID,
+							ChildID:  childID,
+							Type:     domainmodel.AssociationTypeReference,
+							Owner:    owner,
+						},
+					},
+				}, nil
+			},
+		},
+	}
+}
+
+func onlyRetrieveAction(t *testing.T, fb *flowBuilder) *microflows.RetrieveAction {
+	t.Helper()
+	if len(fb.objects) != 1 {
+		t.Fatalf("got %d objects, want 1", len(fb.objects))
+	}
+	activity, ok := fb.objects[0].(*microflows.ActionActivity)
+	if !ok {
+		t.Fatalf("got object %T, want *microflows.ActionActivity", fb.objects[0])
+	}
+	action, ok := activity.Action.(*microflows.RetrieveAction)
+	if !ok {
+		t.Fatalf("got action %T, want *microflows.RetrieveAction", activity.Action)
+	}
+	return action
+}

--- a/mdl/executor/cmd_microflows_builder_retrieve_reverse_test.go
+++ b/mdl/executor/cmd_microflows_builder_retrieve_reverse_test.go
@@ -81,11 +81,38 @@ func TestAddRetrieveAction_ReverseReferenceNonPersistableParentUsesAssociationSo
 	}
 }
 
+func TestAddRetrieveAction_ReferenceSetRegistersOtherEntityListType(t *testing.T) {
+	fb := newRetrieveAssociationFlowBuilderWithType(domainmodel.AssociationTypeReferenceSet, domainmodel.AssociationOwnerBoth, true, true)
+	fb.varTypes["Parent"] = "Sample.Parent"
+
+	fb.addRetrieveAction(&ast.RetrieveStmt{
+		Variable:      "Children",
+		StartVariable: "Parent",
+		Source:        ast.QualifiedName{Module: "Sample", Name: "Parent_Child"},
+	})
+
+	action := onlyRetrieveAction(t, fb)
+	source, ok := action.Source.(*microflows.AssociationRetrieveSource)
+	if !ok {
+		t.Fatalf("reference-set retrieve source = %T, want AssociationRetrieveSource", action.Source)
+	}
+	if source.StartVariable != "Parent" || source.AssociationQualifiedName != "Sample.Parent_Child" {
+		t.Fatalf("association source = %#v", source)
+	}
+	if got := fb.varTypes["Children"]; got != "List of Sample.Child" {
+		t.Fatalf("result var type = %q, want List of Sample.Child", got)
+	}
+}
+
 func newRetrieveAssociationFlowBuilder(owner domainmodel.AssociationOwner) *flowBuilder {
 	return newRetrieveAssociationFlowBuilderWithPersistability(owner, true, true)
 }
 
 func newRetrieveAssociationFlowBuilderWithPersistability(owner domainmodel.AssociationOwner, parentPersistable, childPersistable bool) *flowBuilder {
+	return newRetrieveAssociationFlowBuilderWithType(domainmodel.AssociationTypeReference, owner, parentPersistable, childPersistable)
+}
+
+func newRetrieveAssociationFlowBuilderWithType(associationType domainmodel.AssociationType, owner domainmodel.AssociationOwner, parentPersistable, childPersistable bool) *flowBuilder {
 	moduleID := model.ID("sample-module")
 	parentID := model.ID("parent-entity")
 	childID := model.ID("child-entity")
@@ -113,7 +140,7 @@ func newRetrieveAssociationFlowBuilderWithPersistability(owner domainmodel.Assoc
 							Name:     "Parent_Child",
 							ParentID: parentID,
 							ChildID:  childID,
-							Type:     domainmodel.AssociationTypeReference,
+							Type:     associationType,
 							Owner:    owner,
 						},
 					},

--- a/mdl/executor/cmd_microflows_format_action.go
+++ b/mdl/executor/cmd_microflows_format_action.go
@@ -299,6 +299,10 @@ func formatAction(
 				entityName = "Entity"
 			}
 
+			if startVar, assocName, ok := parseReverseAssociationRetrieve(ctx, dbSource, entityName); ok {
+				return fmt.Sprintf("retrieve $%s from $%s/%s;", outputVar, startVar, assocName)
+			}
+
 			stmt := fmt.Sprintf("retrieve $%s from %s", outputVar, entityName)
 
 			if dbSource.XPathConstraint != "" {
@@ -1135,6 +1139,156 @@ func formatTransformJsonAction(a *microflows.TransformJsonAction) string {
 	sb.WriteString(a.Transformation)
 	sb.WriteString(";")
 	return sb.String()
+}
+
+func parseReverseAssociationRetrieve(
+	ctx *ExecContext,
+	source *microflows.DatabaseRetrieveSource,
+	entityName string,
+) (string, string, bool) {
+	if ctx == nil || ctx.Backend == nil || source == nil || entityName == "" {
+		return "", "", false
+	}
+	if len(source.Sorting) > 0 || !isRangeAllOrNil(source.Range) {
+		return "", "", false
+	}
+
+	assocName, startVar, ok := parseReverseAssociationXPath(source.XPathConstraint)
+	if !ok || !databaseRetrieveMatchesAssociationTarget(ctx, entityName, assocName) {
+		return "", "", false
+	}
+	return startVar, assocName, true
+}
+
+func isRangeAllOrNil(r *microflows.Range) bool {
+	return r == nil || r.RangeType == "" || r.RangeType == microflows.RangeTypeAll
+}
+
+func parseReverseAssociationXPath(raw string) (string, string, bool) {
+	parts, ok := splitTopLevelXPathPredicates(raw)
+	if !ok || len(parts) != 1 {
+		return "", "", false
+	}
+
+	condition := strings.TrimSpace(parts[0])
+	if strings.ContainsAny(condition, "<>!") || strings.Count(condition, "=") != 1 {
+		return "", "", false
+	}
+
+	sides := strings.SplitN(condition, "=", 2)
+	assocName := strings.TrimSpace(sides[0])
+	startVar := strings.TrimSpace(sides[1])
+	if !isQualifiedAssociationName(assocName) || !strings.HasPrefix(startVar, "$") {
+		return "", "", false
+	}
+
+	startVar = strings.TrimPrefix(startVar, "$")
+	if !isSimpleMendixName(startVar) {
+		return "", "", false
+	}
+	return assocName, startVar, true
+}
+
+func isQualifiedAssociationName(name string) bool {
+	parts := strings.Split(name, ".")
+	return len(parts) == 2 && isSimpleMendixName(parts[0]) && isSimpleMendixName(parts[1])
+}
+
+func isSimpleMendixName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || i > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func databaseRetrieveMatchesAssociationTarget(ctx *ExecContext, entityName, assocQualifiedName string) bool {
+	moduleName, assocName, ok := strings.Cut(assocQualifiedName, ".")
+	if !ok {
+		return false
+	}
+
+	mod, err := ctx.Backend.GetModuleByName(moduleName)
+	if err != nil || mod == nil {
+		return false
+	}
+	dm, err := ctx.Backend.GetDomainModel(mod.ID)
+	if err != nil || dm == nil {
+		return false
+	}
+
+	entityNames := make(map[model.ID]string, len(dm.Entities))
+	for _, entity := range dm.Entities {
+		entityNames[entity.ID] = moduleName + "." + entity.Name
+	}
+	for _, assoc := range dm.Associations {
+		if assoc.Name == assocName {
+			return entityNames[assoc.ParentID] == entityName
+		}
+	}
+	return false
+}
+
+func splitTopLevelXPathPredicates(raw string) ([]string, bool) {
+	var parts []string
+	input := strings.TrimSpace(raw)
+	if input == "" {
+		return nil, false
+	}
+
+	i := 0
+	for i < len(input) {
+		for i < len(input) && (input[i] == ' ' || input[i] == '\t' || input[i] == '\r' || input[i] == '\n') {
+			i++
+		}
+		if i >= len(input) {
+			break
+		}
+		if input[i] != '[' {
+			return nil, false
+		}
+
+		start := i + 1
+		depth := 1
+		var quote byte
+		for i = start; i < len(input); i++ {
+			ch := input[i]
+			if quote != 0 {
+				if ch == quote {
+					quote = 0
+				}
+				continue
+			}
+			switch ch {
+			case '\'', '"':
+				quote = ch
+			case '[':
+				depth++
+			case ']':
+				depth--
+				if depth == 0 {
+					part := strings.TrimSpace(input[start:i])
+					parts = append(parts, part)
+					i++
+					goto nextPredicate
+				}
+			}
+		}
+		return nil, false
+
+	nextPredicate:
+	}
+
+	if len(parts) == 0 {
+		return nil, false
+	}
+
+	return parts, true
 }
 
 // --- Executor method wrappers for callers in unmigrated code and tests ---

--- a/mdl/executor/cmd_microflows_format_action_test.go
+++ b/mdl/executor/cmd_microflows_format_action_test.go
@@ -5,7 +5,9 @@ package executor
 import (
 	"testing"
 
+	"github.com/mendixlabs/mxcli/mdl/backend/mock"
 	"github.com/mendixlabs/mxcli/model"
+	"github.com/mendixlabs/mxcli/sdk/domainmodel"
 	"github.com/mendixlabs/mxcli/sdk/microflows"
 )
 
@@ -671,5 +673,119 @@ func TestFormatAction_Retrieve_Association(t *testing.T) {
 	want := "retrieve $Address from $Customer/MyModule.Customer_Address;"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatAction_Retrieve_ReverseAssociationDatabaseSourceUsesCompactForm(t *testing.T) {
+	e := newTestExecutor()
+	e.backend = reverseAssociationBackend(t)
+	action := &microflows.RetrieveAction{
+		OutputVariable: "Domains",
+		Source: &microflows.DatabaseRetrieveSource{
+			EntityQualifiedName: "SampleRuntime.Domain",
+			XPathConstraint:     "[SampleRuntime.Domain_Runtime = $Runtime]",
+			Range:               &microflows.Range{RangeType: microflows.RangeTypeAll},
+		},
+	}
+
+	got := e.formatAction(action, nil, nil)
+	want := "retrieve $Domains from $Runtime/SampleRuntime.Domain_Runtime;"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatAction_Retrieve_ReverseAssociationRequiresSimpleAllRange(t *testing.T) {
+	e := newTestExecutor()
+	e.backend = reverseAssociationBackend(t)
+	action := &microflows.RetrieveAction{
+		OutputVariable: "Domains",
+		Source: &microflows.DatabaseRetrieveSource{
+			EntityQualifiedName: "SampleRuntime.Domain",
+			XPathConstraint:     "[SampleRuntime.Domain_Runtime = $Runtime]",
+			Range:               &microflows.Range{RangeType: microflows.RangeTypeFirst},
+		},
+	}
+
+	got := e.formatAction(action, nil, nil)
+	want := "retrieve $Domains from SampleRuntime.Domain\n    where SampleRuntime.Domain_Runtime = $Runtime\n    limit 1;"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatAction_Retrieve_ReverseAssociationRequiresMatchingEntity(t *testing.T) {
+	e := newTestExecutor()
+	e.backend = reverseAssociationBackend(t)
+	action := &microflows.RetrieveAction{
+		OutputVariable: "Domains",
+		Source: &microflows.DatabaseRetrieveSource{
+			EntityQualifiedName: "SampleRuntime.Runtime",
+			XPathConstraint:     "[SampleRuntime.Domain_Runtime = $Runtime]",
+		},
+	}
+
+	got := e.formatAction(action, nil, nil)
+	want := "retrieve $Domains from SampleRuntime.Runtime\n    where SampleRuntime.Domain_Runtime = $Runtime;"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestParseReverseAssociationXPathRejectsComplexPredicates(t *testing.T) {
+	tests := []string{
+		"[SampleRuntime.Domain_Runtime = $Runtime][Active = true]",
+		"[SampleRuntime.Domain_Runtime != $Runtime]",
+		"[SampleRuntime.Domain_Runtime = $Runtime/Other.Assoc]",
+		"[SampleRuntime.Domain_Runtime = 'literal']",
+		"SampleRuntime.Domain_Runtime = $Runtime",
+	}
+
+	for _, tt := range tests {
+		if assoc, start, ok := parseReverseAssociationXPath(tt); ok {
+			t.Fatalf("parseReverseAssociationXPath(%q) = %q, %q, true; want false", tt, assoc, start)
+		}
+	}
+}
+
+func reverseAssociationBackend(t *testing.T) *mock.MockBackend {
+	t.Helper()
+	moduleID := model.ID("sample-runtime-module")
+	return &mock.MockBackend{
+		GetModuleByNameFunc: func(name string) (*model.Module, error) {
+			if name != "SampleRuntime" {
+				return nil, nil
+			}
+			return &model.Module{
+				BaseElement: model.BaseElement{ID: moduleID},
+				Name:        "SampleRuntime",
+			}, nil
+		},
+		GetDomainModelFunc: func(id model.ID) (*domainmodel.DomainModel, error) {
+			if id != moduleID {
+				return nil, nil
+			}
+			return &domainmodel.DomainModel{
+				ContainerID: moduleID,
+				Entities: []*domainmodel.Entity{
+					{
+						BaseElement: model.BaseElement{ID: "domain-entity"},
+						Name:        "Domain",
+					},
+					{
+						BaseElement: model.BaseElement{ID: "runtime-entity"},
+						Name:        "Runtime",
+					},
+				},
+				Associations: []*domainmodel.Association{
+					{
+						Name:     "Domain_Runtime",
+						ParentID: "domain-entity",
+						ChildID:  "runtime-entity",
+						Type:     domainmodel.AssociationTypeReference,
+					},
+				},
+			}, nil
+		},
 	}
 }


### PR DESCRIPTION
Closes part of #352.
Part of #332.

## Summary

This extracts the reverse-association retrieve formatter fix from the audit staging branch.

Some Mendix models store a compact association retrieve as a database retrieve with a single XPath predicate like `[Module.Association = $Variable]` and range `All`. The formatter previously described that as a verbose database retrieve with a `where` clause, causing avoidable describe/exec/describe drift.

## Changes

- Detect the narrow reverse-association database retrieve shape.
- Verify through the backend domain model that the association target matches the retrieved entity before compacting.
- Emit `retrieve $Result from $Variable/Module.Association;` only for safe `All` range, unsorted, single-predicate cases.
- Keep existing database retrieve output for complex predicates, non-variable RHS, sorting, non-`All` ranges, and non-matching targets.

## Validation

- `make build`
- `make lint-go`
- `make test`
