### PR TITLE
fix: write valid change-action item storage lists

### DIFF
--- a/mdl-examples/bug-tests/373-change-action-items-storage-list.mdl
+++ b/mdl-examples/bug-tests/373-change-action-items-storage-list.mdl
@@ -1,0 +1,50 @@
+-- ============================================================================
+-- Bug #373: Writer emitted invalid ChangeActionItem list markers
+-- ============================================================================
+--
+-- Symptom (before fix):
+--   The microflow BSON writer serialized `CreateChangeAction.Items` and
+--   `ChangeAction.Items` arrays with the COUNT of member changes as the
+--   first BSON array element. Mendix storage lists use a constant
+--   storage-list MARKER there. For ChangeActionItem lists this marker is
+--   `2`, independent of how many items the list contains. Writing the
+--   item count produced unstable microflow BSON for create/change object
+--   actions and could lead to invalid action payloads when Studio Pro
+--   re-loaded the model.
+--
+--   Additionally, `ChangeAction` was missing its default
+--   `ErrorHandlingType: Rollback` field, so the written shape did not
+--   match the expected action payload.
+--
+-- After fix:
+--   - Writer emits `bson.A{int32(2)}` for both CreateChangeAction.Items
+--     and ChangeAction.Items.
+--   - Writer emits the default `ErrorHandlingType: Rollback` for
+--     ChangeAction.
+--
+-- Usage:
+--   mxcli exec mdl-examples/bug-tests/373-change-action-items-storage-list.mdl -p app.mpr
+--   mxcli -p app.mpr -c "describe microflow BugTest373.MF_CreateAndChange"
+--   `mx check` against the resulting MPR must report 0 errors.
+-- ============================================================================
+
+create module BugTest373;
+
+create entity BugTest373.Order (
+  Name : string(100),
+  Status : string(50)
+);
+/
+
+-- Create-with-members and change-with-members both exercise the
+-- ChangeActionItem storage list. After exec, the MPR must load cleanly
+-- in Studio Pro (`mx check` reports 0 errors).
+create microflow BugTest373.MF_CreateAndChange (
+  $Name: string
+)
+returns BugTest373.Order as $Order
+begin
+  $Order = create BugTest373.Order (Name = $Name);
+  change $Order (Status = 'Processed');
+end;
+/

--- a/sdk/mpr/writer_microflow_action_items_test.go
+++ b/sdk/mpr/writer_microflow_action_items_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package mpr
+
+import (
+	"testing"
+
+	"github.com/mendixlabs/mxcli/model"
+	"github.com/mendixlabs/mxcli/sdk/microflows"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestSerializeCreateObjectActionItemsUseStorageListMarker(t *testing.T) {
+	action := &microflows.CreateObjectAction{
+		BaseElement:         model.BaseElement{ID: "create-1"},
+		EntityQualifiedName: "SampleModule.Order",
+		OutputVariable:      "Order",
+		Commit:              microflows.CommitTypeNo,
+		InitialMembers: []*microflows.MemberChange{
+			{
+				BaseElement:            model.BaseElement{ID: "member-1"},
+				AttributeQualifiedName: "SampleModule.Order.Name",
+				Type:                   microflows.MemberChangeTypeSet,
+				Value:                  "'Sample'",
+			},
+		},
+	}
+
+	doc := serializeMicroflowAction(action)
+
+	items, ok := getBSONField(doc, "Items").(bson.A)
+	if !ok {
+		t.Fatalf("Items is %T, want bson.A", getBSONField(doc, "Items"))
+	}
+	if len(items) != 2 {
+		t.Fatalf("Items length = %d, want marker plus one item", len(items))
+	}
+	if marker, ok := items[0].(int32); !ok || marker != 2 {
+		t.Fatalf("Items marker = %#v, want int32(2)", items[0])
+	}
+}
+
+func TestSerializeChangeObjectActionItemsUseStorageListMarkerAndDefaultErrorHandling(t *testing.T) {
+	action := &microflows.ChangeObjectAction{
+		BaseElement:    model.BaseElement{ID: "change-1"},
+		ChangeVariable: "Order",
+		Commit:         microflows.CommitTypeNo,
+		Changes: []*microflows.MemberChange{
+			{
+				BaseElement:            model.BaseElement{ID: "member-1"},
+				AttributeQualifiedName: "SampleModule.Order.Status",
+				Type:                   microflows.MemberChangeTypeSet,
+				Value:                  "'Processed'",
+			},
+		},
+	}
+
+	doc := serializeMicroflowAction(action)
+
+	if got := getBSONField(doc, "ErrorHandlingType"); got != "Rollback" {
+		t.Fatalf("ErrorHandlingType = %#v, want Rollback", got)
+	}
+	items, ok := getBSONField(doc, "Items").(bson.A)
+	if !ok {
+		t.Fatalf("Items is %T, want bson.A", getBSONField(doc, "Items"))
+	}
+	if len(items) != 2 {
+		t.Fatalf("Items length = %d, want marker plus one item", len(items))
+	}
+	if marker, ok := items[0].(int32); !ok || marker != 2 {
+		t.Fatalf("Items marker = %#v, want int32(2)", items[0])
+	}
+}

--- a/sdk/mpr/writer_microflow_actions.go
+++ b/sdk/mpr/writer_microflow_actions.go
@@ -65,9 +65,9 @@ func serializeMicroflowAction(action microflows.MicroflowAction) bson.D {
 		}
 		// ErrorHandlingType is required (default to Rollback)
 		doc = append(doc, bson.E{Key: "ErrorHandlingType", Value: "Rollback"})
-		// Serialize Items (ChangeActionItem) for InitialMembers
-		// IMPORTANT: Mendix BSON arrays include the count as the first element
-		items := bson.A{int32(len(a.InitialMembers))} // Start with count
+		// Serialize Items (ChangeActionItem) for InitialMembers. Mendix stores
+		// this list with storage-list marker 2, not with the item count.
+		items := bson.A{int32(2)}
 		for _, change := range a.InitialMembers {
 			item := bson.D{
 				{Key: "$ID", Value: idToBsonBinary(string(change.ID))},
@@ -99,10 +99,11 @@ func serializeMicroflowAction(action microflows.MicroflowAction) bson.D {
 			{Key: "$Type", Value: "Microflows$ChangeAction"}, // storageName differs from qualifiedName
 			{Key: "ChangeVariableName", Value: a.ChangeVariable},
 			{Key: "Commit", Value: string(a.Commit)},
+			{Key: "ErrorHandlingType", Value: "Rollback"},
 		}
-		// Serialize Items (ChangeActionItem)
-		// IMPORTANT: Mendix BSON arrays include the count as the first element
-		items := bson.A{int32(len(a.Changes))} // Start with count
+		// Serialize Items (ChangeActionItem). Mendix stores this list with
+		// storage-list marker 2, not with the item count.
+		items := bson.A{int32(2)}
 		for _, change := range a.Changes {
 			item := bson.D{
 				{Key: "$ID", Value: idToBsonBinary(string(change.ID))},


### PR DESCRIPTION
Closes #373.

## Summary

- write the Mendix storage-list marker `2` for CreateChangeAction and ChangeAction `Items`
- emit the default `ErrorHandlingType: Rollback` field for ChangeAction
- add focused BSON writer regression tests for create-object and change-object actions

## Validation

- `make build`
- `make lint-go`
- `make test`