### PR TITLE
fix: write REST HttpResponse result variable type

### DIFF
--- a/mdl-examples/bug-tests/375-rest-httpresponse-result-type.mdl
+++ b/mdl-examples/bug-tests/375-rest-httpresponse-result-type.mdl
@@ -1,0 +1,69 @@
+-- ============================================================================
+-- Bug #375: REST HttpResponse result handling serialized as string
+-- ============================================================================
+--
+-- Symptom (before fix):
+--   When a Studio Pro REST call action bound the complete HTTP response
+--   to an output variable, the parser/AST captured this as
+--   `ResultHandlingHttpResponse` and the action-level
+--   `ResultHandlingType` was `HttpResponse`. The writer, however, did
+--   NOT have an explicit branch for `ResultHandlingHttpResponse` inside
+--   `serializeRestResultHandling`, so it fell through to the string
+--   default. The serialized result variable was emitted as
+--   `DataTypes$StringType`, not the expected
+--   `DataTypes$ObjectType` bound to `System.HttpResponse`.
+--   Studio Pro then surfaced a type mismatch on the bound output
+--   variable, and dependent activities that reached into the response
+--   (`$Response/Content`, `$Response/StatusCode`) failed validation
+--   with CE0117.
+--
+-- After fix (writer only):
+--   `serializeRestResultHandling` now has an explicit
+--   `ResultHandlingHttpResponse` branch that emits a `DataTypes$ObjectType`
+--   variable type bound to `System.HttpResponse`.
+--
+-- Scope note — known related gap:
+--   The MDL builder for `rest call ... returns response` still creates
+--   a `ResultHandlingString` (not `ResultHandlingHttpResponse`). See
+--   `mdl/executor/cmd_microflows_builder_calls.go` — the
+--   `case ast.RestResultResponse` arm carries the comment
+--   "we would need a different result type, but using String for now".
+--   That means newly authored MDL with `returns response` does NOT yet
+--   trigger the new writer branch. PR #376 fixes the symptom for
+--   existing Studio Pro models that already contain
+--   `ResultHandlingHttpResponse` in their BSON; the BUILDER side is
+--   tracked separately and verified by the SDK-level Go test
+--   `TestSerializeRestResultHandlingHttpResponseUsesObjectType`, which
+--   constructs the AST directly.
+--
+-- Usage (positive control):
+--   mxcli exec mdl-examples/bug-tests/375-rest-httpresponse-result-type.mdl -p app.mpr
+--   `mx check` against the resulting MPR must report 0 errors. The
+--   negative case (a Studio Pro REST call with HttpResponse binding)
+--   needs the existing BSON shape and is covered by the Go test above.
+-- ============================================================================
+
+create module BugTest375;
+
+-- Inline REST call returning a string. Once the builder learns to emit
+-- ResultHandlingHttpResponse for `returns response`, this script can be
+-- updated to use `returns response` and exercise the writer branch end
+-- to end.
+create microflow BugTest375.MF_RestCall ()
+returns boolean as $Ok
+begin
+  declare $Ok boolean = false;
+
+  $Body = rest call get 'https://httpbin.org/get'
+    header Accept = 'application/json'
+    timeout 15
+    returns string
+    on error continue;
+
+  if $Body != '' then
+    set $Ok = true;
+  end if;
+
+  return $Ok;
+end;
+/

--- a/sdk/mpr/writer_microflow_actions.go
+++ b/sdk/mpr/writer_microflow_actions.go
@@ -793,6 +793,20 @@ func serializeRestResultHandling(rh microflows.ResultHandling, outputVar string)
 		)
 		return doc
 
+	case *microflows.ResultHandlingHttpResponse:
+		return bson.D{
+			{Key: "$ID", Value: idToBsonBinary(string(h.ID))},
+			{Key: "$Type", Value: "Microflows$ResultHandling"},
+			{Key: "Bind", Value: outputVar != ""},
+			{Key: "ImportMappingCall", Value: nil},
+			{Key: "ResultVariableName", Value: outputVar},
+			{Key: "VariableType", Value: bson.D{
+				{Key: "$ID", Value: idToBsonBinary(GenerateID())},
+				{Key: "$Type", Value: "DataTypes$ObjectType"},
+				{Key: "Entity", Value: "System.HttpResponse"},
+			}},
+		}
+
 	case *microflows.ResultHandlingNone:
 		return bson.D{
 			{Key: "$ID", Value: idToBsonBinary(string(h.ID))},

--- a/sdk/mpr/writer_rest_httpresponse_test.go
+++ b/sdk/mpr/writer_rest_httpresponse_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package mpr
+
+import (
+	"testing"
+
+	"github.com/mendixlabs/mxcli/model"
+	"github.com/mendixlabs/mxcli/sdk/microflows"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestSerializeRestResultHandlingHttpResponseUsesObjectType(t *testing.T) {
+	handling := &microflows.ResultHandlingHttpResponse{
+		BaseElement:  model.BaseElement{ID: "result-1"},
+		VariableName: "HttpResponse",
+	}
+
+	doc := serializeRestResultHandling(handling, "HttpResponse")
+
+	if got := getBSONField(doc, "ResultVariableName"); got != "HttpResponse" {
+		t.Fatalf("ResultVariableName = %#v, want HttpResponse", got)
+	}
+	variableType, ok := getBSONField(doc, "VariableType").(bson.D)
+	if !ok {
+		t.Fatalf("VariableType is %T, want bson.D", getBSONField(doc, "VariableType"))
+	}
+	if got := getBSONField(variableType, "$Type"); got != "DataTypes$ObjectType" {
+		t.Fatalf("VariableType.$Type = %#v, want DataTypes$ObjectType", got)
+	}
+	if got := getBSONField(variableType, "Entity"); got != "System.HttpResponse" {
+		t.Fatalf("VariableType.Entity = %#v, want System.HttpResponse", got)
+	}
+}


### PR DESCRIPTION
Closes #375.

## Summary

- add explicit writer support for `ResultHandlingHttpResponse`
- serialize the result variable as `DataTypes$ObjectType` bound to `System.HttpResponse`
- add a focused BSON writer regression test for the REST result handling shape

## Validation

- `make build`
- `make lint-go`
- `make test`