### PR TITLE
fix: preserve object-valued owner-both reverse retrieves

### DIFF
--- a/mdl/executor/cmd_microflows_builder.go
+++ b/mdl/executor/cmd_microflows_builder.go
@@ -37,11 +37,13 @@ type flowBuilder struct {
 	// continues) so the continuing branch's @anchor survives to the actual
 	// splitID→nextActivity flow — which is emitted one iteration later by the
 	// outer loop, not by addIfStatement.
-	nextFlowAnchor     *ast.FlowAnchors
-	backend            backend.FullBackend          // For looking up page/microflow references
-	hierarchy          *ContainerHierarchy          // For resolving container IDs to module names
-	pendingAnnotations *ast.ActivityAnnotations     // Pending annotations to attach to next activity
-	restServices       []*model.ConsumedRestService // Cached REST services for parameter classification
+	nextFlowAnchor       *ast.FlowAnchors
+	backend              backend.FullBackend          // For looking up page/microflow references
+	hierarchy            *ContainerHierarchy          // For resolving container IDs to module names
+	pendingAnnotations   *ast.ActivityAnnotations     // Pending annotations to attach to next activity
+	restServices         []*model.ConsumedRestService // Cached REST services for parameter classification
+	listInputVariables   map[string]bool              // Variables later consumed by list-only actions
+	objectInputVariables map[string]bool              // Variables later consumed through object/attribute access
 	// previousStmtAnchor holds the Anchor annotation of the statement that
 	// just emitted an activity, so the next flow's OriginConnectionIndex can
 	// be overridden by the user. Cleared after each flow is created.

--- a/mdl/executor/cmd_microflows_builder_actions.go
+++ b/mdl/executor/cmd_microflows_builder_actions.go
@@ -302,10 +302,19 @@ func (fb *flowBuilder) addRetrieveAction(s *ast.RetrieveStmt) model.ID {
 			startVarType = fb.varTypes[s.StartVariable]
 		}
 
-		if assocInfo != nil && assocInfo.Type == domainmodel.AssociationTypeReference &&
+		outputUsedAsList := fb.listInputVariables != nil && fb.listInputVariables[s.Variable]
+		outputUsedAsObject := fb.objectInputVariables != nil && fb.objectInputVariables[s.Variable]
+		// Owner-both Reference associations need later usage context: the same
+		// compact retrieve can be consumed as either a list or a single object.
+		expandReverseReference := assocInfo != nil &&
+			assocInfo.Type == domainmodel.AssociationTypeReference &&
 			assocInfo.Owner != "" &&
 			assocInfo.parentPersistable &&
-			assocInfo.childEntityQN != "" && startVarType == assocInfo.childEntityQN {
+			assocInfo.childEntityQN != "" &&
+			startVarType == assocInfo.childEntityQN &&
+			(assocInfo.Owner != domainmodel.AssociationOwnerBoth || outputUsedAsList && !outputUsedAsObject)
+
+		if expandReverseReference {
 			// Reverse traversal on Reference: child → parent (one-to-many)
 			// Use DatabaseRetrieveSource with XPath to get a list of parent entities
 			dbSource := &microflows.DatabaseRetrieveSource{
@@ -333,7 +342,7 @@ func (fb *flowBuilder) addRetrieveAction(s *ast.RetrieveStmt) model.ID {
 					if startVarType == assocInfo.childEntityQN {
 						otherEntity = assocInfo.parentEntityQN
 					}
-					if startVarType == assocInfo.childEntityQN {
+					if startVarType == assocInfo.childEntityQN && !outputUsedAsObject {
 						fb.varTypes[s.Variable] = "List of " + otherEntity
 					} else {
 						fb.varTypes[s.Variable] = otherEntity

--- a/mdl/executor/cmd_microflows_builder_graph.go
+++ b/mdl/executor/cmd_microflows_builder_graph.go
@@ -20,6 +20,12 @@ func (fb *flowBuilder) buildFlowGraph(stmts []ast.MicroflowStatement, returns *a
 	if fb.declaredVars == nil {
 		fb.declaredVars = make(map[string]string)
 	}
+	if fb.listInputVariables == nil {
+		fb.listInputVariables = collectListInputVariables(stmts)
+	}
+	if fb.objectInputVariables == nil {
+		fb.objectInputVariables = collectObjectInputVariables(stmts)
+	}
 	// Set return value expression for error handler EndEvents
 	if returns != nil && returns.Variable != "" {
 		fb.returnValue = "$" + returns.Variable
@@ -159,6 +165,257 @@ func (fb *flowBuilder) buildFlowGraph(stmts []ast.MicroflowStatement, returns *a
 		Flows:           fb.flows,
 		AnnotationFlows: fb.annotationFlows,
 	}
+}
+
+func collectListInputVariables(stmts []ast.MicroflowStatement) map[string]bool {
+	inputs := make(map[string]bool)
+	var walk func([]ast.MicroflowStatement)
+	walk = func(body []ast.MicroflowStatement) {
+		for _, stmt := range body {
+			switch s := stmt.(type) {
+			case *ast.ListOperationStmt:
+				if s.InputVariable != "" {
+					inputs[s.InputVariable] = true
+				}
+			case *ast.AggregateListStmt:
+				if s.InputVariable != "" {
+					inputs[s.InputVariable] = true
+				}
+			case *ast.LoopStmt:
+				if s.ListVariable != "" {
+					inputs[s.ListVariable] = true
+				}
+				walk(s.Body)
+			case *ast.WhileStmt:
+				walk(s.Body)
+			case *ast.IfStmt:
+				walk(s.ThenBody)
+				walk(s.ElseBody)
+			case *ast.CallMicroflowStmt:
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.CallJavaActionStmt:
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.CreateObjectStmt:
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.ChangeObjectStmt:
+				// ChangeObjectStmt has no error-handler clause.
+			case *ast.MfCommitStmt:
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.DeleteObjectStmt:
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.RestCallStmt:
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.SendRestRequestStmt:
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.ImportFromMappingStmt:
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.ExportToMappingStmt:
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			}
+		}
+	}
+	walk(stmts)
+	return inputs
+}
+
+func collectObjectInputVariables(stmts []ast.MicroflowStatement) map[string]bool {
+	inputs := make(map[string]bool)
+	var walkExpr func(ast.Expression)
+	walkExpr = func(expr ast.Expression) {
+		switch e := expr.(type) {
+		case *ast.AttributePathExpr:
+			if e.Variable != "" {
+				inputs[e.Variable] = true
+			}
+		case *ast.BinaryExpr:
+			walkExpr(e.Left)
+			walkExpr(e.Right)
+		case *ast.UnaryExpr:
+			walkExpr(e.Operand)
+		case *ast.FunctionCallExpr:
+			for _, arg := range e.Arguments {
+				walkExpr(arg)
+			}
+		case *ast.ParenExpr:
+			walkExpr(e.Inner)
+		case *ast.IfThenElseExpr:
+			walkExpr(e.Condition)
+			walkExpr(e.ThenExpr)
+			walkExpr(e.ElseExpr)
+		}
+	}
+
+	var walk func([]ast.MicroflowStatement)
+	walk = func(body []ast.MicroflowStatement) {
+		for _, stmt := range body {
+			switch s := stmt.(type) {
+			case *ast.MfSetStmt:
+				walkExpr(s.Value)
+			case *ast.ReturnStmt:
+				walkExpr(s.Value)
+			case *ast.LogStmt:
+				walkExpr(s.Node)
+				walkExpr(s.Message)
+				for _, param := range s.Template {
+					walkExpr(param.Value)
+				}
+			case *ast.CreateObjectStmt:
+				for _, change := range s.Changes {
+					walkExpr(change.Value)
+				}
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.ChangeObjectStmt:
+				if s.Variable != "" {
+					inputs[s.Variable] = true
+				}
+				for _, change := range s.Changes {
+					walkExpr(change.Value)
+				}
+			case *ast.RetrieveStmt:
+				walkExpr(s.Where)
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.IfStmt:
+				walkExpr(s.Condition)
+				walk(s.ThenBody)
+				walk(s.ElseBody)
+			case *ast.LoopStmt:
+				walk(s.Body)
+			case *ast.WhileStmt:
+				walkExpr(s.Condition)
+				walk(s.Body)
+			case *ast.ListOperationStmt:
+				walkExpr(s.Condition)
+			case *ast.AggregateListStmt:
+				walkExpr(s.Expression)
+			case *ast.AddToListStmt:
+				if s.Item != "" {
+					inputs[s.Item] = true
+				}
+			case *ast.CallMicroflowStmt:
+				for _, arg := range s.Arguments {
+					walkExpr(arg.Value)
+				}
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.CallJavaActionStmt:
+				for _, arg := range s.Arguments {
+					walkExpr(arg.Value)
+				}
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.ExecuteDatabaseQueryStmt:
+				for _, arg := range s.Arguments {
+					walkExpr(arg.Value)
+				}
+				for _, arg := range s.ConnectionArguments {
+					walkExpr(arg.Value)
+				}
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.CallExternalActionStmt:
+				for _, arg := range s.Arguments {
+					walkExpr(arg.Value)
+				}
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.RestCallStmt:
+				walkExpr(s.URL)
+				for _, param := range s.URLParams {
+					walkExpr(param.Value)
+				}
+				for _, header := range s.Headers {
+					walkExpr(header.Value)
+				}
+				if s.Body != nil {
+					walkExpr(s.Body.Template)
+					for _, param := range s.Body.TemplateParams {
+						walkExpr(param.Value)
+					}
+				}
+				walkExpr(s.Timeout)
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.SendRestRequestStmt:
+				for _, param := range s.Parameters {
+					for _, ref := range sourceAttributeVarRefs(param.Expression) {
+						inputs[ref] = true
+					}
+				}
+				if s.BodyVariable != "" {
+					inputs[s.BodyVariable] = true
+				}
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.ImportFromMappingStmt:
+				if s.SourceVariable != "" {
+					inputs[s.SourceVariable] = true
+				}
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			case *ast.ExportToMappingStmt:
+				if s.SourceVariable != "" {
+					inputs[s.SourceVariable] = true
+				}
+				if s.ErrorHandling != nil {
+					walk(s.ErrorHandling.Body)
+				}
+			}
+		}
+	}
+	walk(stmts)
+	return inputs
+}
+
+func sourceAttributeVarRefs(source string) []string {
+	var refs []string
+	for i := 0; i < len(source); i++ {
+		if source[i] != '$' {
+			continue
+		}
+		j := i + 1
+		for j < len(source) {
+			c := source[j]
+			if c == '_' || c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z' || c >= '0' && c <= '9' {
+				j++
+				continue
+			}
+			break
+		}
+		if j > i+1 && j < len(source) && source[j] == '/' {
+			refs = append(refs, source[i+1:j])
+		}
+		i = j
+	}
+	return refs
 }
 
 // addStatement converts an AST statement to a microflow activity and returns its ID.

--- a/mdl/executor/cmd_microflows_builder_retrieve_reverse_test.go
+++ b/mdl/executor/cmd_microflows_builder_retrieve_reverse_test.go
@@ -15,6 +15,7 @@ import (
 func TestAddRetrieveAction_ReverseReferenceOwnerBothUsesDatabaseSource(t *testing.T) {
 	fb := newRetrieveAssociationFlowBuilder(domainmodel.AssociationOwnerBoth)
 	fb.varTypes["Child"] = "Sample.Child"
+	fb.listInputVariables = map[string]bool{"Parents": true}
 
 	fb.addRetrieveAction(&ast.RetrieveStmt{
 		Variable:      "Parents",
@@ -32,6 +33,30 @@ func TestAddRetrieveAction_ReverseReferenceOwnerBothUsesDatabaseSource(t *testin
 	}
 	if got := fb.varTypes["Parents"]; got != "List of Sample.Parent" {
 		t.Fatalf("result var type = %q, want List of Sample.Parent", got)
+	}
+}
+
+func TestAddRetrieveAction_ReverseReferenceOwnerBothObjectUsagePreservesAssociationSource(t *testing.T) {
+	fb := newRetrieveAssociationFlowBuilder(domainmodel.AssociationOwnerBoth)
+	fb.varTypes["Child"] = "Sample.Child"
+	fb.objectInputVariables = map[string]bool{"Parent": true}
+
+	fb.addRetrieveAction(&ast.RetrieveStmt{
+		Variable:      "Parent",
+		StartVariable: "Child",
+		Source:        ast.QualifiedName{Module: "Sample", Name: "Parent_Child"},
+	})
+
+	action := onlyRetrieveAction(t, fb)
+	source, ok := action.Source.(*microflows.AssociationRetrieveSource)
+	if !ok {
+		t.Fatalf("owner-both object reverse retrieve source = %T, want AssociationRetrieveSource", action.Source)
+	}
+	if source.StartVariable != "Child" || source.AssociationQualifiedName != "Sample.Parent_Child" {
+		t.Fatalf("association source = %#v", source)
+	}
+	if got := fb.varTypes["Parent"]; got != "Sample.Parent" {
+		t.Fatalf("result var type = %q, want Sample.Parent", got)
 	}
 }
 
@@ -127,6 +152,78 @@ func TestAddRetrieveAction_ReferenceSetRegistersOtherEntityListType(t *testing.T
 	}
 }
 
+func TestBuildFlowGraph_ReverseReferenceOwnerBothAttributeUsagePreservesAssociationSource(t *testing.T) {
+	fb := newRetrieveAssociationFlowBuilder(domainmodel.AssociationOwnerBoth)
+	fb.posX = 200
+	fb.posY = 200
+	fb.spacing = HorizontalSpacing
+	fb.varTypes["Child"] = "Sample.Child"
+	stmts := []ast.MicroflowStatement{
+		&ast.RetrieveStmt{
+			Variable:      "Parent",
+			StartVariable: "Child",
+			Source:        ast.QualifiedName{Module: "Sample", Name: "Parent_Child"},
+		},
+		&ast.CallMicroflowStmt{
+			MicroflowName: ast.QualifiedName{Module: "Sample", Name: "UseParent"},
+			Arguments: []ast.CallArgument{
+				{
+					Name:  "parentName",
+					Value: &ast.AttributePathExpr{Variable: "Parent", Path: []string{"Name"}},
+				},
+			},
+		},
+	}
+
+	fb.buildFlowGraph(stmts, nil)
+
+	action := firstRetrieveAction(t, fb)
+	source, ok := action.Source.(*microflows.AssociationRetrieveSource)
+	if !ok {
+		t.Fatalf("owner-both attribute usage source = %T, want AssociationRetrieveSource", action.Source)
+	}
+	if source.StartVariable != "Child" || source.AssociationQualifiedName != "Sample.Parent_Child" {
+		t.Fatalf("association source = %#v", source)
+	}
+	if got := fb.varTypes["Parent"]; got != "Sample.Parent" {
+		t.Fatalf("result var type = %q, want Sample.Parent", got)
+	}
+}
+
+func TestBuildFlowGraph_ReverseReferenceOwnerBothLoopUsageUsesDatabaseSource(t *testing.T) {
+	fb := newRetrieveAssociationFlowBuilder(domainmodel.AssociationOwnerBoth)
+	fb.posX = 200
+	fb.posY = 200
+	fb.spacing = HorizontalSpacing
+	fb.varTypes["Child"] = "Sample.Child"
+	stmts := []ast.MicroflowStatement{
+		&ast.RetrieveStmt{
+			Variable:      "Parents",
+			StartVariable: "Child",
+			Source:        ast.QualifiedName{Module: "Sample", Name: "Parent_Child"},
+		},
+		&ast.LoopStmt{
+			LoopVariable: "Parent",
+			ListVariable: "Parents",
+			Body:         []ast.MicroflowStatement{},
+		},
+	}
+
+	fb.buildFlowGraph(stmts, nil)
+
+	action := firstRetrieveAction(t, fb)
+	source, ok := action.Source.(*microflows.DatabaseRetrieveSource)
+	if !ok {
+		t.Fatalf("owner-both loop usage source = %T, want DatabaseRetrieveSource", action.Source)
+	}
+	if source.EntityQualifiedName != "Sample.Parent" || source.XPathConstraint != "[Sample.Parent_Child = $Child]" {
+		t.Fatalf("database source = %#v", source)
+	}
+	if got := fb.varTypes["Parents"]; got != "List of Sample.Parent" {
+		t.Fatalf("result var type = %q, want List of Sample.Parent", got)
+	}
+}
+
 func newRetrieveAssociationFlowBuilder(owner domainmodel.AssociationOwner) *flowBuilder {
 	return newRetrieveAssociationFlowBuilderWithPersistability(owner, true, true)
 }
@@ -187,4 +284,20 @@ func onlyRetrieveAction(t *testing.T, fb *flowBuilder) *microflows.RetrieveActio
 		t.Fatalf("got action %T, want *microflows.RetrieveAction", activity.Action)
 	}
 	return action
+}
+
+func firstRetrieveAction(t *testing.T, fb *flowBuilder) *microflows.RetrieveAction {
+	t.Helper()
+	for _, object := range fb.objects {
+		activity, ok := object.(*microflows.ActionActivity)
+		if !ok {
+			continue
+		}
+		action, ok := activity.Action.(*microflows.RetrieveAction)
+		if ok {
+			return action
+		}
+	}
+	t.Fatalf("retrieve action not found in %d objects", len(fb.objects))
+	return nil
 }


### PR DESCRIPTION
Closes #383.

## Summary

- pre-scans microflow statements for variables later consumed as list inputs or object/attribute inputs
- keeps owner-both reverse `Reference` retrieves as database/list retrieves only for list consumers
- preserves compact association retrieves and object-valued builder typing when the result is dereferenced as an object

## Validation

- `make build`
- `make test`
- `make lint-go`
- targeted Mendix `mx check` repro on a copied MPR returned 0 errors
