### PR TITLE
fix: emit loop captions during microflow describe

### DIFF
--- a/mdl/executor/cmd_microflows_show_helpers.go
+++ b/mdl/executor/cmd_microflows_show_helpers.go
@@ -462,6 +462,9 @@ func emitObjectAnnotations(
 	if split, ok := obj.(*microflows.InheritanceSplit); ok && split.Caption != "" {
 		*lines = append(*lines, indentStr+fmt.Sprintf("@caption %s", mdlQuote(split.Caption)))
 	}
+	if loop, ok := obj.(*microflows.LoopedActivity); ok && loop.Caption != "" {
+		*lines = append(*lines, indentStr+fmt.Sprintf("@caption %s", mdlQuote(loop.Caption)))
+	}
 
 	// @annotation (attached Annotation objects)
 	if annotationsByTarget != nil {

--- a/mdl/executor/cmd_microflows_show_helpers_test.go
+++ b/mdl/executor/cmd_microflows_show_helpers_test.go
@@ -160,6 +160,25 @@ func TestEmitObjectAnnotations_EscapesMultilineText(t *testing.T) {
 	}
 }
 
+func TestEmitObjectAnnotations_LoopCaption(t *testing.T) {
+	obj := &microflows.LoopedActivity{
+		BaseMicroflowObject: microflows.BaseMicroflowObject{
+			BaseElement: model.BaseElement{ID: mkID("loop")},
+			Position:    model.Point{X: 100, Y: 200},
+		},
+		Caption: "Loop owner's\ncaption",
+	}
+
+	var lines []string
+	// Pass nil flow maps — @anchor emission is intentionally suppressed here.
+	emitObjectAnnotations(obj, &lines, "", nil, nil, nil, nil)
+
+	got := strings.Join(lines, "\n")
+	if !strings.Contains(got, "@caption 'Loop owner''s\\ncaption'") {
+		t.Fatalf("expected escaped loop caption, got:\n%s", got)
+	}
+}
+
 func TestPrependFreeAnnotationLines_ModelAnnotationsStayFree(t *testing.T) {
 	oc := &microflows.MicroflowObjectCollection{
 		Objects: []microflows.MicroflowObject{


### PR DESCRIPTION
Closes #443.

## Summary

- Emit `@caption` for `microflows.LoopedActivity` during microflow describe.
- Use the same `mdlQuote` path as other activity captions.
- Add a focused regression test covering apostrophe and newline escaping in loop captions.

## Validation

- `make build`
- `go test ./mdl/executor -run 'TestEmitObjectAnnotations_LoopCaption|TestLoopCaptionPreserved|TestWhileLoopCaptionPreserved' -v`
- `make test`
- `make lint-go`