### PR TITLE
test: cover empty EndEvent return serialization

### DIFF
--- a/sdk/mpr/writer_microflow_version_test.go
+++ b/sdk/mpr/writer_microflow_version_test.go
@@ -86,12 +86,12 @@ func TestSerializeEndEvent_EmptyReturnValueHasNoTrailingLineBreak(t *testing.T) 
 			Position:    model.Point{X: 10, Y: 20},
 			Size:        model.Size{Width: 20, Height: 20},
 		},
-		ReturnValue: "empty",
+		ReturnValue: "",
 	}
 
 	doc := serializeMicroflowObject(end)
-	if got := bsonGetKey(doc, "ReturnValue"); got != "empty" {
-		t.Fatalf("ReturnValue = %q, want %q", got, "empty")
+	if got := bsonGetKey(doc, "ReturnValue"); got != "" {
+		t.Fatalf("ReturnValue = %q, want empty string", got)
 	}
 }
 


### PR DESCRIPTION
Closes #445.

## Summary

- Update the EndEvent writer regression test to use an actual empty string `ReturnValue`.
- Keep the non-empty return serialization test unchanged for the existing `$Result` case.

## Validation

- `make build`
- `go test ./sdk/mpr -run 'TestSerializeEndEvent_EmptyReturnValueHasNoTrailingLineBreak|TestSerializeEndEvent_NonEmptyReturnValueHasNoSyntheticLineBreak' -v`
- `make test`
- `make lint-go`