### PR TITLE
fix: preserve incoming anchors for inheritance splits

### DIFF
--- a/mdl/executor/cmd_microflows_show_helpers.go
+++ b/mdl/executor/cmd_microflows_show_helpers.go
@@ -128,11 +128,11 @@ func emitAnchorAnnotationWithActivityMap(
 	id := obj.GetID()
 
 	if _, isSplit := obj.(*microflows.ExclusiveSplit); isSplit {
-		emitSplitAnchorAnnotation(id, flowsByOrigin, flowsByDest, lines, indentStr)
+		emitSplitAnchorAnnotation(id, flowsByOrigin, flowsByDest, lines, indentStr, false)
 		return
 	}
 	if _, isSplit := obj.(*microflows.InheritanceSplit); isSplit {
-		emitSplitAnchorAnnotation(id, flowsByOrigin, flowsByDest, lines, indentStr)
+		emitSplitAnchorAnnotation(id, flowsByOrigin, flowsByDest, lines, indentStr, true)
 		return
 	}
 	if loop, isLoop := obj.(*microflows.LoopedActivity); isLoop {
@@ -203,6 +203,7 @@ func emitSplitAnchorAnnotation(
 	flowsByDest map[model.ID][]*microflows.SequenceFlow,
 	lines *[]string,
 	indentStr string,
+	preserveDefaultIncoming bool,
 ) {
 	// Incoming flow anchor (where the previous activity's flow lands on the split).
 	var inTo string
@@ -227,12 +228,12 @@ func emitSplitAnchorAnnotation(
 	}
 
 	var parts []string
-	splitDefaultIn := anchorSideKeyword(AnchorLeft)
 	trueDefaultFroms := []string{anchorSideKeyword(AnchorRight), anchorSideKeyword(AnchorBottom)}
 	trueDefaultTos := []string{anchorSideKeyword(AnchorLeft)}
 	falseDefaultFroms := []string{anchorSideKeyword(AnchorBottom), anchorSideKeyword(AnchorRight)}
 	falseDefaultTos := []string{anchorSideKeyword(AnchorTop), anchorSideKeyword(AnchorLeft)}
-	if inTo != "" && inTo != splitDefaultIn {
+	splitDefaultIn := anchorSideKeyword(AnchorLeft)
+	if inTo != "" && (preserveDefaultIncoming || inTo != splitDefaultIn) {
 		parts = append(parts, "to: "+inTo)
 	}
 	if p := branchAnchorFragmentWithDefaultSides("true", trueFrom, trueTo, trueDefaultFroms, trueDefaultTos); p != "" {

--- a/mdl/executor/cmd_microflows_split_incoming_anchor_test.go
+++ b/mdl/executor/cmd_microflows_split_incoming_anchor_test.go
@@ -7,8 +7,10 @@
 // on the flow entering the split, but the describer never read it back.
 //
 // The fix moves split anchors into a dedicated emitSplitAnchorAnnotation path
-// that emits `@anchor(to: X, true: (...), false: (...))` whenever any of the
-// three has a non-default value.
+// that emits `@anchor(to: X, true: (...), false: (...))` whenever any split
+// has a non-default value. For inheritance splits the incoming side is also
+// preserved when it is `left`: omitting it can make the builder relayout
+// negative-X split-type branches and change branch scoping.
 package executor
 
 import (
@@ -46,6 +48,30 @@ func TestEmitSplitAnchor_EmitsIncomingToSide(t *testing.T) {
 	// The split has no outgoing flows, so true/false fragments must be absent.
 	if strings.Contains(lines[0], "true:") || strings.Contains(lines[0], "false:") {
 		t.Errorf("no outgoing flows configured, but output contains branch fragment: %q", lines[0])
+	}
+}
+
+func TestEmitSplitAnchor_PreservesIncomingLeftSide(t *testing.T) {
+	splitID := model.ID("split-left-incoming")
+	split := &microflows.InheritanceSplit{}
+	split.ID = splitID
+
+	incoming := &microflows.SequenceFlow{
+		DestinationID:              splitID,
+		DestinationConnectionIndex: AnchorLeft,
+	}
+	flowsByDest := map[model.ID][]*microflows.SequenceFlow{
+		splitID: {incoming},
+	}
+
+	var lines []string
+	emitAnchorAnnotation(split, nil, flowsByDest, &lines, "")
+
+	if len(lines) != 1 {
+		t.Fatalf("expected incoming anchor line, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "@anchor(to: left)" {
+		t.Fatalf("anchor line = %q, want @anchor(to: left)", lines[0])
 	}
 }
 


### PR DESCRIPTION
Closes #453.

## Summary

- keep default incoming-anchor suppression for regular exclusive splits
- preserve incoming `to: left` anchors for inheritance splits because they can affect split-type branch geometry and scoping
- add a synthetic regression test for inheritance split incoming-anchor emission

## Validation

- `go test ./mdl/executor -run 'TestEmitSplitAnchor|TestDescribe_FalseBranchFromTop_IfWithoutElseIsDefault'`
- `make build`
- `make test`