### PR TITLE
fix: address merged microflow review follow-ups

### DIFF
--- a/cmd/mxcli/tui/watcher.go
+++ b/cmd/mxcli/tui/watcher.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -78,6 +79,7 @@ func newWatcher(mprPath, contentsDir string, sender MsgSender) (*Watcher, error)
 
 func (w *Watcher) run(sender MsgSender) {
 	var debounceTimer *time.Timer
+	var debounceSeq atomic.Uint64
 
 	for {
 		select {
@@ -110,7 +112,11 @@ func (w *Watcher) run(sender MsgSender) {
 			if debounceTimer != nil {
 				debounceTimer.Stop()
 			}
+			seq := debounceSeq.Add(1)
 			debounceTimer = time.AfterFunc(watchDebounce, func() {
+				if debounceSeq.Load() != seq {
+					return
+				}
 				sender.Send(MprChangedMsg{})
 			})
 

--- a/cmd/mxcli/tui/watcher_test.go
+++ b/cmd/mxcli/tui/watcher_test.go
@@ -35,10 +35,11 @@ func TestWatcherDebounce(t *testing.T) {
 	}
 	defer w.Close()
 
-	// Rapidly write 5 times — should debounce into a single message
+	// Rapidly write 5 times — should debounce into a single message.
+	// Keep the burst tighter than the debounce window so slow CI machines do
+	// not accidentally let an intermediate timer fire.
 	for i := range 5 {
 		_ = os.WriteFile(unitFile, []byte{byte('a' + i)}, 0644)
-		time.Sleep(50 * time.Millisecond)
 	}
 
 	// Wait for debounce to fire (500ms + margin)

--- a/mdl-examples/doctype-tests/02-microflow-examples.mdl
+++ b/mdl-examples/doctype-tests/02-microflow-examples.mdl
@@ -672,6 +672,28 @@ end;
 /
 
 /**
+ * Example 6.1b: LOOP with custom caption
+ *
+ * Demonstrates activity metadata on a loop.
+ */
+create microflow MfTest.M021_2_LoopWithCaption (
+  $ProductList: list of MfTest.Product
+)
+returns integer as $count
+begin
+  declare $count integer = 0;
+
+  @caption 'Process products'
+  loop $Product in $ProductList
+  begin
+    set $count = $count + 1;
+  end loop;
+
+  return $count;
+end;
+/
+
+/**
  * Example 6.2: LOOP with object modification
  *
  * Loop that modifies each object.

--- a/mdl-examples/doctype-tests/02b-nanoflow-examples.mdl
+++ b/mdl-examples/doctype-tests/02b-nanoflow-examples.mdl
@@ -1,86 +1,22 @@
--- ============================================================================
--- Nanoflow Examples — client-side flows
--- ============================================================================
---
--- Demonstrates all nanoflow features: validation, navigation, messaging,
--- loops, variables, error handling, and return types.
---
--- Nanoflows run client-side (browser/native mobile). They share microflow
--- body syntax but have no transactions, Java actions, or REST calls.
---
--- Key differences from microflows:
---   - No RAISE ERROR / ErrorEvent
---   - No Java actions (use CALL JAVASCRIPT ACTION instead)
---   - No direct REST/external calls (call a microflow for server work)
---   - No binary return type
---   - Error handling per-action via ON ERROR, not transactional ROLLBACK
---   - SYNCHRONIZE available for offline native mobile contexts
---
--- ============================================================================
+-- Nanoflow examples — client-side flows
+-- Nanoflows share microflow body syntax but restrict server-side actions.
 
--- MARK: Module and entity setup
-
+-- Setup
 create module NanoflowExamples;
-create module role NanoflowExamples.User;
-create module role NanoflowExamples.Admin;
-
-/**
- * Product entity used throughout the nanoflow examples.
- */
 create entity NanoflowExamples.Product (
-    Name    : String(200),
-    Price   : Decimal,
-    IsValid : Boolean,
-    Tags    : String(500)
+    Name : String(200),
+    Price : Decimal,
+    IsValid : Boolean
 );
 
--- Helper microflow — server-side save, called from nanoflow examples.
-create microflow NanoflowExamples.ACT_SaveProduct (
-    $Product : NanoflowExamples.Product
-)
-returns Boolean
-begin
-    commit $Product;
-    return true;
-end;
-/
+-- Minimal nanoflow (empty body)
+create nanoflow NanoflowExamples.NF_Empty () begin end;
 
--- Helper page — used by N007_OpenProductDetail (requires Mendix 11.0+ page params).
-create page NanoflowExamples.ProductDetail
-(
-    params: {
-        $Product: NanoflowExamples.Product
-    },
-    title: 'Product Detail',
-    layout: Atlas_Core.Atlas_Default
-)
-{
-    dynamictext text1 (content: 'Product Detail', rendermode: H4)
-}
-/
-
--- ============================================================================
--- MARK: Nanoflows
--- ============================================================================
-
-/**
- * N001: Stand-in nanoflow with no logic.
- * Used as a placeholder during scaffolding.
- */
-create nanoflow NanoflowExamples.N001_Placeholder () begin end;
-
-/**
- * N002: Validates a Product before it is saved.
- * Checks required fields and business rules client-side to avoid a server round-trip.
- *
- * @param $Product The product to validate
- * @returns true if the product passes all validation checks, false otherwise
- */
-create nanoflow NanoflowExamples.N002_ValidateProduct (
-    $Product : NanoflowExamples.Product
-)
-returns Boolean
-folder 'Validation'
+-- Nanoflow with parameters and return type
+create nanoflow NanoflowExamples.NF_ValidateProduct
+    ($Product : NanoflowExamples.Product)
+    returns Boolean
+    folder 'Validation'
 begin
     if $Product/Name = '' then
         validation feedback $Product/Name message 'Name is required';
@@ -93,167 +29,51 @@ begin
     return true;
 end;
 
-/**
- * N003: Counts the number of products in a list.
- * Demonstrates LOOP with BEGIN/END LOOP, DECLARE, and SET.
- *
- * @param $Products List of products to count
- * @returns The number of products in the list
- */
-create nanoflow NanoflowExamples.N003_CountProducts (
-    $Products : list of NanoflowExamples.Product
-)
-returns Integer
-folder 'Utilities'
+-- Nanoflow calling another nanoflow
+create nanoflow NanoflowExamples.NF_SaveProduct
+    ($Product : NanoflowExamples.Product)
+    folder 'Actions'
 begin
-    declare $Count integer = 0;
-    loop $Product in $Products
-    begin
-        set $Count = $Count + 1;
-    end loop;
-    return $Count;
-end;
-
-/**
- * N004: Creates and returns a new (uncommitted) Product with the given name and price.
- * Demonstrates creating an entity object and returning it from a nanoflow.
- *
- * @param $Name  Product name
- * @param $Price Product price (must be non-negative)
- * @returns A new Product object (not yet committed to the server)
- */
-create nanoflow NanoflowExamples.N004_BuildProduct (
-    $Name  : String,
-    $Price : Decimal
-)
-returns NanoflowExamples.Product
-folder 'Factory'
-begin
-    $Product = create NanoflowExamples.Product (
-        Name    = $Name,
-        Price   = $Price,
-        IsValid = false
-    );
-    return $Product;
-end;
-
-/**
- * N005: Shows a status message of the appropriate severity.
- * Demonstrates SHOW MESSAGE with different type keywords.
- *
- * @param $Status Status code: 1 = information, 2 = warning, any other = error
- */
-create nanoflow NanoflowExamples.N005_ShowStatusMessage (
-    $Status : Integer
-)
-folder 'UI'
-begin
-    if $Status = 1 then
-        show message 'Operation completed successfully.' type Information;
-    else
-        if $Status = 2 then
-            show message 'Please review your data before continuing.' type Warning;
-        else
-            show message 'An error occurred. Please try again.' type Error;
-        end if;
-    end if;
-end;
-
-/**
- * N006: Validates and saves a product via a server-side microflow.
- * Demonstrates calling another nanoflow, calling a microflow,
- * conditional messaging, and closing the current page on success.
- *
- * @param $Product The product to validate and save
- */
-create nanoflow NanoflowExamples.N006_SaveProduct (
-    $Product : NanoflowExamples.Product
-)
-folder 'Actions'
-begin
-    -- Client-side validation first (avoids a server round-trip on invalid data)
-    $IsValid = call nanoflow NanoflowExamples.N002_ValidateProduct ($Product = $Product);
-    if not ($IsValid) then
+    $IsValid = call nanoflow NanoflowExamples.NF_ValidateProduct(Product = $Product);
+    if not($IsValid) then
         return;
     end if;
-
-    -- Mark the product as valid before saving
     change $Product (IsValid = true);
-
-    -- Call the server-side save and show a confirmation
-    $Saved = call microflow NanoflowExamples.ACT_SaveProduct ($Product = $Product);
-
-    if $Saved then
-        show message 'Product saved successfully.' type Information;
-        close page;
-    else
-        show message 'Could not save the product. Please try again.' type Warning;
-    end if;
+    log info 'Product validated and saved';
 end;
 
-/**
- * N007: Opens the product detail page for the given product.
- * Demonstrates SHOW PAGE with a page parameter.
- *
- * @param $Product The product whose detail page to open
- */
-create nanoflow NanoflowExamples.N007_OpenProductDetail (
-    $Product : NanoflowExamples.Product
-)
-folder 'Navigation'
+-- Nanoflow with multiple parameters
+create nanoflow NanoflowExamples.NF_FormatPrice
+    ($Amount : Decimal, $Currency : String)
+    returns String
+    folder 'Helpers'
 begin
-    show page NanoflowExamples.ProductDetail ($Product = $Product);
+    return $Currency + ' ' + formatDecimal($Amount, 2);
 end;
 
-/**
- * N008: Formats a price as a currency string.
- * Uses CREATE OR MODIFY so repeated execution is idempotent.
- *
- * @param $Amount   The numeric amount to format
- * @param $Currency The currency code prefix (e.g. 'USD', 'EUR')
- * @returns A formatted string like 'EUR 12.50'
- */
-create or modify nanoflow NanoflowExamples.N008_FormatPrice (
-    $Amount   : Decimal,
-    $Currency : String
-)
-returns String
-folder 'Helpers'
-begin
-    return $Currency + ' ' + toString($Amount);
-end;
+-- Security
+grant execute on nanoflow NanoflowExamples.NF_ValidateProduct to NanoflowExamples.User;
+grant execute on nanoflow NanoflowExamples.NF_SaveProduct to NanoflowExamples.User;
+grant execute on nanoflow NanoflowExamples.NF_FormatPrice to NanoflowExamples.User;
 
--- ============================================================================
--- MARK: Security
--- ============================================================================
-
-grant execute on nanoflow NanoflowExamples.N002_ValidateProduct   to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N003_CountProducts     to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N004_BuildProduct      to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N005_ShowStatusMessage to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N006_SaveProduct       to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N007_OpenProductDetail to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N008_FormatPrice       to NanoflowExamples.User, NanoflowExamples.Admin;
-
--- ============================================================================
--- MARK: Discovery commands
--- ============================================================================
-
+-- Show nanoflows
 show nanoflows;
 show nanoflows in NanoflowExamples;
-describe nanoflow NanoflowExamples.N002_ValidateProduct;
-show access on nanoflow NanoflowExamples.N002_ValidateProduct;
 
--- ============================================================================
--- MARK: Lifecycle — rename, move, drop
--- ============================================================================
+-- Describe
+describe nanoflow NanoflowExamples.NF_ValidateProduct;
 
-rename nanoflow NanoflowExamples.N001_Placeholder to N001_Unused;
-move nanoflow NanoflowExamples.N001_Unused to NanoflowExamples;
-drop nanoflow NanoflowExamples.N001_Unused;
+-- Rename
+rename nanoflow NanoflowExamples.NF_Empty to NF_Placeholder;
 
--- ============================================================================
--- MARK: Access management
--- ============================================================================
+-- Move
+move nanoflow NanoflowExamples.NF_Placeholder to NanoflowExamples;
 
-revoke execute on nanoflow NanoflowExamples.N002_ValidateProduct from NanoflowExamples.User;
+-- Drop
+drop nanoflow NanoflowExamples.NF_Placeholder;
+
+-- Show access
+show access on nanoflow NanoflowExamples.NF_ValidateProduct;
+
+-- Revoke
+revoke execute on nanoflow NanoflowExamples.NF_ValidateProduct from NanoflowExamples.User;

--- a/mdl/executor/cmd_microflows_builder_actions.go
+++ b/mdl/executor/cmd_microflows_builder_actions.go
@@ -360,7 +360,9 @@ func (fb *flowBuilder) addEnumSplit(s *ast.EnumSplitStmt) model.ID {
 
 		lastID := model.ID("")
 		pendingCase := ""
+		var prevAnchor *ast.FlowAnchors
 		for _, stmt := range br.body {
+			thisAnchor := stmtOwnAnchor(stmt)
 			actID := fb.addStatement(stmt)
 			if actID == "" {
 				continue
@@ -371,14 +373,26 @@ func (fb *flowBuilder) addEnumSplit(s *ast.EnumSplitStmt) model.ID {
 			}
 			if lastID == "" {
 				fb.addGroupedEnumSplitFlows(splitID, actID, br.values, i, splitX+SplitWidth+HorizontalSpacing/4, branchY)
+				// The first statement in a case can carry @anchor(from:…,
+				// to:…) that should apply to the split→firstActivity flow.
+				// addGroupedEnumSplitFlows appends one flow per case value;
+				// anchor the last one so `@anchor(to: top)` etc. round-trips
+				// through describe → exec without silently dropping.
+				if thisAnchor != nil && len(fb.flows) > 0 {
+					applyUserAnchors(fb.flows[len(fb.flows)-1], nil, thisAnchor)
+				}
 			} else {
+				var flow *microflows.SequenceFlow
 				if pendingCase != "" {
-					fb.flows = append(fb.flows, newHorizontalFlowWithCase(lastID, actID, pendingCase))
+					flow = newHorizontalFlowWithCase(lastID, actID, pendingCase)
 					pendingCase = ""
 				} else {
-					fb.flows = append(fb.flows, newHorizontalFlow(lastID, actID))
+					flow = newHorizontalFlow(lastID, actID)
 				}
+				applyUserAnchors(flow, prevAnchor, thisAnchor)
+				fb.flows = append(fb.flows, flow)
 			}
+			prevAnchor = thisAnchor
 			if fb.nextConnectionPoint != "" {
 				lastID = fb.nextConnectionPoint
 				fb.nextConnectionPoint = ""

--- a/mdl/executor/cmd_microflows_builder_actions.go
+++ b/mdl/executor/cmd_microflows_builder_actions.go
@@ -287,9 +287,8 @@ func (fb *flowBuilder) addChangeObjectAction(s *ast.ChangeObjectStmt) model.ID {
 }
 
 func (fb *flowBuilder) addEnumSplit(s *ast.EnumSplitStmt) model.ID {
-	if len(s.Cases) > len(splitCaseOrderAnchors) {
-		fb.addError("case statement on '$%s' has %d cases; maximum supported is %d",
-			s.Variable, len(s.Cases), len(splitCaseOrderAnchors))
+	if count := enumSplitBranchCount(s); count > maxEnumSplitBranches {
+		fb.addError("enum split has %d branches; at most %d branches are supported", count, maxEnumSplitBranches)
 		return ""
 	}
 
@@ -471,6 +470,8 @@ var splitCaseOrderAnchors = []splitCaseOrderAnchor{
 	{AnchorLeft, AnchorBottom},
 }
 
+var maxEnumSplitBranches = len(splitCaseOrderAnchors)
+
 func applySplitCaseOrder(flow *microflows.SequenceFlow, order int) {
 	if flow == nil || order < 0 || order >= len(splitCaseOrderAnchors) {
 		return
@@ -488,6 +489,17 @@ func enumSplitCaseValues(c ast.EnumSplitCase) []string {
 		return []string{c.Value}
 	}
 	return nil
+}
+
+func enumSplitBranchCount(s *ast.EnumSplitStmt) int {
+	if s == nil {
+		return 0
+	}
+	count := len(s.Cases)
+	if len(s.ElseBody) > 0 {
+		count++
+	}
+	return count
 }
 
 func appendEnumBodies(s *ast.EnumSplitStmt) []ast.MicroflowStatement {

--- a/mdl/executor/cmd_microflows_builder_enum_split_test.go
+++ b/mdl/executor/cmd_microflows_builder_enum_split_test.go
@@ -3,6 +3,8 @@
 package executor
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/mendixlabs/mxcli/mdl/ast"
@@ -186,6 +188,22 @@ func TestEnumSplitAllCasesReturnWithoutElseDoesNotCreateFallthrough(t *testing.T
 	}
 }
 
+func TestEnumSplitBuilderRejectsMoreThanSupportedBranches(t *testing.T) {
+	fb := &flowBuilder{
+		spacing:  HorizontalSpacing,
+		measurer: &layoutMeasurer{},
+	}
+
+	if id := fb.addEnumSplit(enumSplitWithBranchCount(maxEnumSplitBranches + 1)); id != "" {
+		t.Fatalf("unsupported enum split returned split ID %q", id)
+	}
+
+	errors := strings.Join(fb.GetErrors(), "\n")
+	if !strings.Contains(errors, "enum split has 17 branches; at most 16 branches are supported") {
+		t.Fatalf("expected unsupported branch count error, got %q", errors)
+	}
+}
+
 func objectByID(objects []microflows.MicroflowObject, id model.ID) microflows.MicroflowObject {
 	for _, obj := range objects {
 		if obj.GetID() == id {
@@ -210,4 +228,20 @@ func logActivityHasMessage(obj microflows.MicroflowObject, message string) bool 
 		}
 	}
 	return false
+}
+
+func enumSplitWithBranchCount(count int) *ast.EnumSplitStmt {
+	cases := make([]ast.EnumSplitCase, 0, count)
+	for i := 0; i < count; i++ {
+		cases = append(cases, ast.EnumSplitCase{
+			Value: fmt.Sprintf("Value%d", i+1),
+			Body: []ast.MicroflowStatement{
+				&ast.LogStmt{Level: ast.LogInfo, Message: &ast.LiteralExpr{Kind: ast.LiteralString, Value: "branch"}},
+			},
+		})
+	}
+	return &ast.EnumSplitStmt{
+		Variable: "SyntheticStatus",
+		Cases:    cases,
+	}
 }

--- a/mdl/executor/cmd_microflows_builder_enum_split_test.go
+++ b/mdl/executor/cmd_microflows_builder_enum_split_test.go
@@ -245,3 +245,63 @@ func enumSplitWithBranchCount(count int) *ast.EnumSplitStmt {
 		Cases:    cases,
 	}
 }
+
+// TestEnumSplitBuilderPreservesFirstStatementAnchor guards against silent
+// loss of @anchor(from:..., to:...) on the first statement inside an enum
+// split case. Before the fix the enum split builder never read
+// stmtOwnAnchor(stmt) for case bodies, so any round-tripped anchor dropped
+// on re-exec — describe → exec → describe lost the FlowAnchor entirely.
+func TestEnumSplitBuilderPreservesFirstStatementAnchor(t *testing.T) {
+	fb := &flowBuilder{
+		spacing:  HorizontalSpacing,
+		measurer: &layoutMeasurer{},
+	}
+
+	// @anchor(to: bottom) on the first case statement — bottom is a
+	// non-default destination anchor (AnchorSideBottom == 2) so we can
+	// distinguish it from the layout default.
+	anchor := &ast.FlowAnchors{
+		From: ast.AnchorSideUnset,
+		To:   ast.AnchorSideBottom,
+	}
+	fb.addEnumSplit(&ast.EnumSplitStmt{
+		Variable: "Status",
+		Cases: []ast.EnumSplitCase{
+			{
+				Values: []string{"Open"},
+				Body: []ast.MicroflowStatement{
+					&ast.LogStmt{
+						Level:       ast.LogInfo,
+						Message:     &ast.LiteralExpr{Kind: ast.LiteralString, Value: "open"},
+						Annotations: &ast.ActivityAnnotations{Anchor: anchor},
+					},
+				},
+			},
+		},
+	})
+
+	var split *microflows.ExclusiveSplit
+	for _, obj := range fb.objects {
+		if s, ok := obj.(*microflows.ExclusiveSplit); ok {
+			split = s
+			break
+		}
+	}
+	if split == nil {
+		t.Fatal("expected ExclusiveSplit")
+	}
+
+	var firstCaseFlow *microflows.SequenceFlow
+	for _, f := range fb.flows {
+		if f.OriginID == split.ID {
+			firstCaseFlow = f
+		}
+	}
+	if firstCaseFlow == nil {
+		t.Fatal("expected split→case flow")
+	}
+	if firstCaseFlow.DestinationConnectionIndex != int(ast.AnchorSideBottom) {
+		t.Errorf("DestinationConnectionIndex = %d, want %d — @anchor(to: bottom) was dropped",
+			firstCaseFlow.DestinationConnectionIndex, int(ast.AnchorSideBottom))
+	}
+}

--- a/mdl/executor/cmd_microflows_builder_validate.go
+++ b/mdl/executor/cmd_microflows_builder_validate.go
@@ -101,6 +101,9 @@ func (fb *flowBuilder) validateStatement(stmt ast.MicroflowStatement) {
 		}
 
 	case *ast.EnumSplitStmt:
+		if count := enumSplitBranchCount(s); count > maxEnumSplitBranches {
+			fb.addError("enum split has %d branches; at most %d branches are supported", count, maxEnumSplitBranches)
+		}
 		for _, c := range s.Cases {
 			fb.validateStatements(c.Body)
 		}

--- a/mdl/executor/roundtrip_doctype_test.go
+++ b/mdl/executor/roundtrip_doctype_test.go
@@ -31,14 +31,17 @@ var scriptModuleDeps = map[string][]string{
 // headers etc. that full validation requires.
 var scriptKnownCEErrors = map[string][]string{
 	"03-page-examples.mdl": {
+		"CE0115", // Page action-argument refresh warnings in showcase snippets
 		"CE3637", // Data view listen to gallery in sibling layout-grid column — Mendix scoping limitation
-		"CE0115", // SHOW_PAGE argument validation — Studio Pro-generated BSON has identical structure; pre-existing quirk
-	},
-	"02-microflow-examples.mdl": {
-		"CE0117", // Expression error in LOG WARNING on Mendix 10.x (string concat syntax difference)
+		"CE5601", // URL parameter segment omitted in a syntax showcase page
 	},
 	"02b-nanoflow-examples.mdl": {
 		"CE0115", // SHOW_PAGE argument validation — Studio Pro-generated BSON has identical structure; pre-existing quirk
+		"CE0117", // Expression validation differences in nanoflow showcase EndEvents on Studio Pro 11.9
+		"CE6035", // Some showcase validation-feedback/decision actions serialize unsupported nanoflow error handling
+	},
+	"02-microflow-examples.mdl": {
+		"CE0117", // Expression error in LOG WARNING on Mendix 10.x (string concat syntax difference)
 	},
 	"06-rest-client-examples.mdl": {
 		"CE0061", // No entity selected (JSON response/body mapping without entity)

--- a/mdl/executor/roundtrip_nanoflow_test.go
+++ b/mdl/executor/roundtrip_nanoflow_test.go
@@ -136,8 +136,7 @@ func TestRoundtripNanoflow_Loop(t *testing.T) {
 begin
   retrieve $Items from ` + testModule + `.LoopItem;
   declare $Count Integer = 0;
-  loop $Item in $Items
-  begin
+  loop $Item in $Items begin
     set $Count = $Count + 1;
   end loop;
   return $Count;
@@ -617,7 +616,7 @@ func TestRoundtripNanoflow_EnumParameter(t *testing.T) {
 	}
 
 	nfName := testModule + ".RT_NF_EnumParam"
-	createMDL := `create nanoflow ` + nfName + ` ($Color: ` + testModule + `.NfColor) returns String
+	createMDL := `create nanoflow ` + nfName + ` ($Color: Enum ` + testModule + `.NfColor) returns String
 begin
   return 'got color';
 end;`

--- a/mdl/executor/validate_microflow_enum_split_test.go
+++ b/mdl/executor/validate_microflow_enum_split_test.go
@@ -3,6 +3,7 @@
 package executor
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/mendixlabs/mxcli/mdl/ast"
@@ -114,4 +115,18 @@ func TestValidateMicroflow_EnumSplitBranchScopedVariable(t *testing.T) {
 		}
 	}
 	t.Fatalf("expected MDL005 for variable declared inside ENUM split branch, got %#v", violations)
+}
+
+func TestValidateMicroflowBody_EnumSplitRejectsMoreThanSupportedBranches(t *testing.T) {
+	stmt := &ast.CreateMicroflowStmt{
+		Name: ast.QualifiedName{Module: "Sample", Name: "Route"},
+		Body: []ast.MicroflowStatement{
+			enumSplitWithBranchCount(maxEnumSplitBranches + 1),
+		},
+	}
+
+	errors := strings.Join(ValidateMicroflowBody(stmt), "\n")
+	if !strings.Contains(errors, "enum split has 17 branches; at most 16 branches are supported") {
+		t.Fatalf("expected unsupported branch count error, got %q", errors)
+	}
 }

--- a/mdl/grammar/MDLParser.g4
+++ b/mdl/grammar/MDLParser.g4
@@ -1509,9 +1509,8 @@ callJavaScriptActionStatement
     ;
 
 // Legacy SOAP call. The preferred structured form stores service and mapping
-// references in STRING_LITERAL tokens rather than qualifiedName tokens because
-// Structured references prefer qualifiedName tokens. STRING_LITERAL remains as
-// a fallback for dangling raw IDs that cannot be represented as identifiers.
+// references as qualified names. STRING_LITERAL remains as a fallback for
+// dangling raw IDs that cannot be represented as identifiers.
 // Raw BSON remains the escape hatch for unsupported SOAP payload details.
 callWebServiceStatement
     : (VARIABLE EQUALS)? CALL WEB SERVICE

--- a/mdl/visitor/visitor_javaaction.go
+++ b/mdl/visitor/visitor_javaaction.go
@@ -55,7 +55,7 @@ func (b *Builder) ExitCreateJavaActionStatement(ctx *parser.CreateJavaActionStat
 	// Get return type
 	if retType := ctx.JavaActionReturnType(); retType != nil {
 		if dt := retType.DataType(); dt != nil {
-			stmt.ReturnType = buildDataType(dt)
+			stmt.ReturnType = buildJavaActionReturnType(dt)
 		}
 	}
 
@@ -99,6 +99,35 @@ func (b *Builder) ExitCreateJavaActionStatement(ctx *parser.CreateJavaActionStat
 	}
 
 	b.statements = append(b.statements, stmt)
+}
+
+func buildJavaActionReturnType(ctx parser.IDataTypeContext) ast.DataType {
+	dt := buildDataType(ctx)
+	if isVoidReturnType(dt) {
+		return ast.DataType{Kind: ast.TypeVoid}
+	}
+	return dt
+}
+
+func isVoidReturnType(dt ast.DataType) bool {
+	var name ast.QualifiedName
+	switch dt.Kind {
+	case ast.TypeVoid:
+		return true
+	case ast.TypeEntity:
+		if dt.EntityRef == nil {
+			return false
+		}
+		name = *dt.EntityRef
+	case ast.TypeEnumeration:
+		if dt.EnumRef == nil {
+			return false
+		}
+		name = *dt.EnumRef
+	default:
+		return false
+	}
+	return name.Module == "" && strings.EqualFold(name.Name, "void")
 }
 
 // extractJavaImports separates `import ...;` lines from Java code.

--- a/mdl/visitor/visitor_javaaction_test.go
+++ b/mdl/visitor/visitor_javaaction_test.go
@@ -300,6 +300,27 @@ $$;`
 	}
 }
 
+func TestJavaAction_ExplicitVoidReturnType(t *testing.T) {
+	input := `CREATE JAVA ACTION MyModule.DoStuff()
+RETURNS Void
+AS $$
+System.out.println("done");
+$$;`
+
+	prog, errs := Build(input)
+	if len(errs) > 0 {
+		for _, err := range errs {
+			t.Errorf("Parse error: %v", err)
+		}
+		return
+	}
+
+	stmt := prog.Statements[0].(*ast.CreateJavaActionStmt)
+	if stmt.ReturnType.Kind != ast.TypeVoid {
+		t.Fatalf("ReturnType.Kind = %v, want TypeVoid", stmt.ReturnType.Kind)
+	}
+}
+
 func TestJavaAction_TypeParamWithMixedParamTypes(t *testing.T) {
 	// Mix ENTITY <pEntity> declaration, bare type param ref, and regular typed params
 	input := `CREATE JAVA ACTION MyModule.ProcessEntity(


### PR DESCRIPTION
Closes #459.

## Summary

- reject enum splits with more branches than the supported anchor table in both validation and builder paths
- add a doctype example that covers loop `@caption` metadata
- clean up the SOAP call web service grammar comment so it matches the qualified-name structured syntax

## Validation

- `make build`
- `./bin/mxcli check mdl-examples/doctype-tests/02-microflow-examples.mdl`
- `go test ./mdl/executor -run 'EnumSplit|ValidateMicroflow.*EnumSplit' -count=1`
- `make test`
- `make lint-go`