### PR TITLE
fix: emit merge flow for empty ELSE bodies (CE0079)

### DIFF
--- a/mdl/executor/cmd_microflows_builder_control.go
+++ b/mdl/executor/cmd_microflows_builder_control.go
@@ -272,6 +272,12 @@ func (fb *flowBuilder) addIfStatement(s *ast.IfStmt) model.ID {
 				}
 				applyUserAnchors(flow, originAnchor, destAnchor)
 				fb.flows = append(fb.flows, flow)
+			} else {
+				// Explicit empty ELSE body: the split still needs a configured
+				// false case when both branches converge at the merge.
+				flow := newDownwardFlowWithCase(splitID, mergeID, "false")
+				applyUserAnchors(flow, falseBranchAnchor, falseBranchAnchor)
+				fb.flows = append(fb.flows, flow)
 			}
 		} else if elseReturns && needMerge {
 			fb.addPendingErrorHandlerFlowTo(mergeID)

--- a/mdl/executor/cmd_microflows_builder_empty_else_merge_test.go
+++ b/mdl/executor/cmd_microflows_builder_empty_else_merge_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/mendixlabs/mxcli/mdl/ast"
+	"github.com/mendixlabs/mxcli/sdk/microflows"
+)
+
+// TestIfEmptyElseBodyWithContinuingThenEmitsFalseFlowToMerge is a regression
+// guard for CE0079 ("The 'false' condition value should be configured in
+// properties for an outgoing flow").
+//
+// Pattern: an IF with THEN that continues and an explicitly empty ELSE body.
+// Both branches must feed a merge, but an empty ELSE has no lastElseID to wire.
+func TestIfEmptyElseBodyWithContinuingThenEmitsFalseFlowToMerge(t *testing.T) {
+	fb := &flowBuilder{
+		spacing:  HorizontalSpacing,
+		measurer: &layoutMeasurer{},
+	}
+
+	fb.addIfStatement(&ast.IfStmt{
+		Condition: &ast.VariableExpr{Name: "Flag"},
+		ThenBody: []ast.MicroflowStatement{
+			&ast.LogStmt{Level: ast.LogInfo, Message: &ast.LiteralExpr{Kind: ast.LiteralString, Value: "in-then"}},
+		},
+		// The source had an explicit ELSE token, but no statements in that
+		// branch. That must still build a false split->merge flow.
+		HasElse: true,
+	})
+
+	var split *microflows.ExclusiveSplit
+	var merge *microflows.ExclusiveMerge
+	for _, obj := range fb.objects {
+		switch o := obj.(type) {
+		case *microflows.ExclusiveSplit:
+			split = o
+		case *microflows.ExclusiveMerge:
+			merge = o
+		}
+	}
+	if split == nil {
+		t.Fatal("expected ExclusiveSplit to be created")
+	}
+	if merge == nil {
+		t.Fatal("expected ExclusiveMerge to be created")
+	}
+
+	var hasFalseFlow bool
+	for _, flow := range fb.flows {
+		if flow.OriginID != split.ID || flow.DestinationID != merge.ID {
+			continue
+		}
+		if ec, ok := flow.CaseValue.(microflows.EnumerationCase); ok && ec.Value == "false" {
+			hasFalseFlow = true
+		}
+	}
+	if !hasFalseFlow {
+		t.Fatal("missing split->merge flow with case \"false\"")
+	}
+}


### PR DESCRIPTION
## Summary

- The IF builder skipped the split→merge flow when the ELSE body was empty but the merge was still needed (THEN continues). Studio Pro rejected the graph with **CE0079** ("The 'false' condition value should be configured in properties for an outgoing flow") because the split had no outgoing flow for the `false` case.
- Mirrors the existing empty-THEN handling by emitting a direct split→merge flow with case `false`.
- Builds on the `IfStmt.HasElse` support now present on `main`, so the test distinguishes an omitted ELSE from an explicitly empty ELSE.

## Test plan

- [x] `make build`
- [x] `make test`
- [x] `make lint-go`
- [x] New builder unit test `TestIfEmptyElseBodyWithContinuingThenEmitsFalseFlowToMerge` asserts the split emits a `false` case flow into the merge
- [x] The regression test sets `HasElse: true`, so it exercises the explicit empty-ELSE path instead of the no-ELSE path

🤖 Generated with [Claude Code](https://claude.com/claude-code)