### PR TITLE
fix: emit swapped split headers only once

### DIFF
--- a/cmd/mxcli/tui/watcher.go
+++ b/cmd/mxcli/tui/watcher.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -78,6 +79,7 @@ func newWatcher(mprPath, contentsDir string, sender MsgSender) (*Watcher, error)
 
 func (w *Watcher) run(sender MsgSender) {
 	var debounceTimer *time.Timer
+	var debounceSeq atomic.Uint64
 
 	for {
 		select {
@@ -110,7 +112,11 @@ func (w *Watcher) run(sender MsgSender) {
 			if debounceTimer != nil {
 				debounceTimer.Stop()
 			}
+			seq := debounceSeq.Add(1)
 			debounceTimer = time.AfterFunc(watchDebounce, func() {
+				if debounceSeq.Load() != seq {
+					return
+				}
 				sender.Send(MprChangedMsg{})
 			})
 

--- a/cmd/mxcli/tui/watcher_test.go
+++ b/cmd/mxcli/tui/watcher_test.go
@@ -35,10 +35,11 @@ func TestWatcherDebounce(t *testing.T) {
 	}
 	defer w.Close()
 
-	// Rapidly write 5 times — should debounce into a single message
+	// Rapidly write 5 times — should debounce into a single message.
+	// Keep the burst tighter than the debounce window so slow CI machines do
+	// not accidentally let an intermediate timer fire.
 	for i := range 5 {
 		_ = os.WriteFile(unitFile, []byte{byte('a' + i)}, 0644)
-		time.Sleep(50 * time.Millisecond)
 	}
 
 	// Wait for debounce to fire (500ms + margin)

--- a/mdl-examples/doctype-tests/02b-nanoflow-examples.mdl
+++ b/mdl-examples/doctype-tests/02b-nanoflow-examples.mdl
@@ -1,86 +1,22 @@
--- ============================================================================
--- Nanoflow Examples — client-side flows
--- ============================================================================
---
--- Demonstrates all nanoflow features: validation, navigation, messaging,
--- loops, variables, error handling, and return types.
---
--- Nanoflows run client-side (browser/native mobile). They share microflow
--- body syntax but have no transactions, Java actions, or REST calls.
---
--- Key differences from microflows:
---   - No RAISE ERROR / ErrorEvent
---   - No Java actions (use CALL JAVASCRIPT ACTION instead)
---   - No direct REST/external calls (call a microflow for server work)
---   - No binary return type
---   - Error handling per-action via ON ERROR, not transactional ROLLBACK
---   - SYNCHRONIZE available for offline native mobile contexts
---
--- ============================================================================
+-- Nanoflow examples — client-side flows
+-- Nanoflows share microflow body syntax but restrict server-side actions.
 
--- MARK: Module and entity setup
-
+-- Setup
 create module NanoflowExamples;
-create module role NanoflowExamples.User;
-create module role NanoflowExamples.Admin;
-
-/**
- * Product entity used throughout the nanoflow examples.
- */
 create entity NanoflowExamples.Product (
-    Name    : String(200),
-    Price   : Decimal,
-    IsValid : Boolean,
-    Tags    : String(500)
+    Name : String(200),
+    Price : Decimal,
+    IsValid : Boolean
 );
 
--- Helper microflow — server-side save, called from nanoflow examples.
-create microflow NanoflowExamples.ACT_SaveProduct (
-    $Product : NanoflowExamples.Product
-)
-returns Boolean
-begin
-    commit $Product;
-    return true;
-end;
-/
+-- Minimal nanoflow (empty body)
+create nanoflow NanoflowExamples.NF_Empty () begin end;
 
--- Helper page — used by N007_OpenProductDetail (requires Mendix 11.0+ page params).
-create page NanoflowExamples.ProductDetail
-(
-    params: {
-        $Product: NanoflowExamples.Product
-    },
-    title: 'Product Detail',
-    layout: Atlas_Core.Atlas_Default
-)
-{
-    dynamictext text1 (content: 'Product Detail', rendermode: H4)
-}
-/
-
--- ============================================================================
--- MARK: Nanoflows
--- ============================================================================
-
-/**
- * N001: Stand-in nanoflow with no logic.
- * Used as a placeholder during scaffolding.
- */
-create nanoflow NanoflowExamples.N001_Placeholder () begin end;
-
-/**
- * N002: Validates a Product before it is saved.
- * Checks required fields and business rules client-side to avoid a server round-trip.
- *
- * @param $Product The product to validate
- * @returns true if the product passes all validation checks, false otherwise
- */
-create nanoflow NanoflowExamples.N002_ValidateProduct (
-    $Product : NanoflowExamples.Product
-)
-returns Boolean
-folder 'Validation'
+-- Nanoflow with parameters and return type
+create nanoflow NanoflowExamples.NF_ValidateProduct
+    ($Product : NanoflowExamples.Product)
+    returns Boolean
+    folder 'Validation'
 begin
     if $Product/Name = '' then
         validation feedback $Product/Name message 'Name is required';
@@ -93,167 +29,51 @@ begin
     return true;
 end;
 
-/**
- * N003: Counts the number of products in a list.
- * Demonstrates LOOP with BEGIN/END LOOP, DECLARE, and SET.
- *
- * @param $Products List of products to count
- * @returns The number of products in the list
- */
-create nanoflow NanoflowExamples.N003_CountProducts (
-    $Products : list of NanoflowExamples.Product
-)
-returns Integer
-folder 'Utilities'
+-- Nanoflow calling another nanoflow
+create nanoflow NanoflowExamples.NF_SaveProduct
+    ($Product : NanoflowExamples.Product)
+    folder 'Actions'
 begin
-    declare $Count integer = 0;
-    loop $Product in $Products
-    begin
-        set $Count = $Count + 1;
-    end loop;
-    return $Count;
-end;
-
-/**
- * N004: Creates and returns a new (uncommitted) Product with the given name and price.
- * Demonstrates creating an entity object and returning it from a nanoflow.
- *
- * @param $Name  Product name
- * @param $Price Product price (must be non-negative)
- * @returns A new Product object (not yet committed to the server)
- */
-create nanoflow NanoflowExamples.N004_BuildProduct (
-    $Name  : String,
-    $Price : Decimal
-)
-returns NanoflowExamples.Product
-folder 'Factory'
-begin
-    $Product = create NanoflowExamples.Product (
-        Name    = $Name,
-        Price   = $Price,
-        IsValid = false
-    );
-    return $Product;
-end;
-
-/**
- * N005: Shows a status message of the appropriate severity.
- * Demonstrates SHOW MESSAGE with different type keywords.
- *
- * @param $Status Status code: 1 = information, 2 = warning, any other = error
- */
-create nanoflow NanoflowExamples.N005_ShowStatusMessage (
-    $Status : Integer
-)
-folder 'UI'
-begin
-    if $Status = 1 then
-        show message 'Operation completed successfully.' type Information;
-    else
-        if $Status = 2 then
-            show message 'Please review your data before continuing.' type Warning;
-        else
-            show message 'An error occurred. Please try again.' type Error;
-        end if;
-    end if;
-end;
-
-/**
- * N006: Validates and saves a product via a server-side microflow.
- * Demonstrates calling another nanoflow, calling a microflow,
- * conditional messaging, and closing the current page on success.
- *
- * @param $Product The product to validate and save
- */
-create nanoflow NanoflowExamples.N006_SaveProduct (
-    $Product : NanoflowExamples.Product
-)
-folder 'Actions'
-begin
-    -- Client-side validation first (avoids a server round-trip on invalid data)
-    $IsValid = call nanoflow NanoflowExamples.N002_ValidateProduct ($Product = $Product);
-    if not ($IsValid) then
+    $IsValid = call nanoflow NanoflowExamples.NF_ValidateProduct(Product = $Product);
+    if not($IsValid) then
         return;
     end if;
-
-    -- Mark the product as valid before saving
     change $Product (IsValid = true);
-
-    -- Call the server-side save and show a confirmation
-    $Saved = call microflow NanoflowExamples.ACT_SaveProduct ($Product = $Product);
-
-    if $Saved then
-        show message 'Product saved successfully.' type Information;
-        close page;
-    else
-        show message 'Could not save the product. Please try again.' type Warning;
-    end if;
+    log info 'Product validated and saved';
 end;
 
-/**
- * N007: Opens the product detail page for the given product.
- * Demonstrates SHOW PAGE with a page parameter.
- *
- * @param $Product The product whose detail page to open
- */
-create nanoflow NanoflowExamples.N007_OpenProductDetail (
-    $Product : NanoflowExamples.Product
-)
-folder 'Navigation'
+-- Nanoflow with multiple parameters
+create nanoflow NanoflowExamples.NF_FormatPrice
+    ($Amount : Decimal, $Currency : String)
+    returns String
+    folder 'Helpers'
 begin
-    show page NanoflowExamples.ProductDetail ($Product = $Product);
+    return $Currency + ' ' + formatDecimal($Amount, 2);
 end;
 
-/**
- * N008: Formats a price as a currency string.
- * Uses CREATE OR MODIFY so repeated execution is idempotent.
- *
- * @param $Amount   The numeric amount to format
- * @param $Currency The currency code prefix (e.g. 'USD', 'EUR')
- * @returns A formatted string like 'EUR 12.50'
- */
-create or modify nanoflow NanoflowExamples.N008_FormatPrice (
-    $Amount   : Decimal,
-    $Currency : String
-)
-returns String
-folder 'Helpers'
-begin
-    return $Currency + ' ' + toString($Amount);
-end;
+-- Security
+grant execute on nanoflow NanoflowExamples.NF_ValidateProduct to NanoflowExamples.User;
+grant execute on nanoflow NanoflowExamples.NF_SaveProduct to NanoflowExamples.User;
+grant execute on nanoflow NanoflowExamples.NF_FormatPrice to NanoflowExamples.User;
 
--- ============================================================================
--- MARK: Security
--- ============================================================================
-
-grant execute on nanoflow NanoflowExamples.N002_ValidateProduct   to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N003_CountProducts     to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N004_BuildProduct      to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N005_ShowStatusMessage to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N006_SaveProduct       to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N007_OpenProductDetail to NanoflowExamples.User;
-grant execute on nanoflow NanoflowExamples.N008_FormatPrice       to NanoflowExamples.User, NanoflowExamples.Admin;
-
--- ============================================================================
--- MARK: Discovery commands
--- ============================================================================
-
+-- Show nanoflows
 show nanoflows;
 show nanoflows in NanoflowExamples;
-describe nanoflow NanoflowExamples.N002_ValidateProduct;
-show access on nanoflow NanoflowExamples.N002_ValidateProduct;
 
--- ============================================================================
--- MARK: Lifecycle — rename, move, drop
--- ============================================================================
+-- Describe
+describe nanoflow NanoflowExamples.NF_ValidateProduct;
 
-rename nanoflow NanoflowExamples.N001_Placeholder to N001_Unused;
-move nanoflow NanoflowExamples.N001_Unused to NanoflowExamples;
-drop nanoflow NanoflowExamples.N001_Unused;
+-- Rename
+rename nanoflow NanoflowExamples.NF_Empty to NF_Placeholder;
 
--- ============================================================================
--- MARK: Access management
--- ============================================================================
+-- Move
+move nanoflow NanoflowExamples.NF_Placeholder to NanoflowExamples;
 
-revoke execute on nanoflow NanoflowExamples.N002_ValidateProduct from NanoflowExamples.User;
+-- Drop
+drop nanoflow NanoflowExamples.NF_Placeholder;
+
+-- Show access
+show access on nanoflow NanoflowExamples.NF_ValidateProduct;
+
+-- Revoke
+revoke execute on nanoflow NanoflowExamples.NF_ValidateProduct from NanoflowExamples.User;

--- a/mdl/executor/cmd_microflows_show_helpers.go
+++ b/mdl/executor/cmd_microflows_show_helpers.go
@@ -641,11 +641,6 @@ func traverseFlow(
 			}
 			return
 		}
-		if stmt != "" {
-			emitObjectAnnotations(obj, lines, indentStr, annotationsByTarget, flowsByOrigin, flowsByDest, activityMap)
-			*lines = append(*lines, indentStr+stmt)
-		}
-
 		trueFlow, falseFlow := findBranchFlows(flows)
 
 		// Empty-then swap: when the true branch goes directly to the merge
@@ -804,11 +799,6 @@ func traverseFlowUntilMerge(
 			}
 			return
 		}
-		if stmt != "" {
-			emitObjectAnnotations(obj, lines, indentStr, annotationsByTarget, flowsByOrigin, flowsByDest, activityMap)
-			*lines = append(*lines, indentStr+stmt)
-		}
-
 		trueFlow, falseFlow := findBranchFlows(flows)
 
 		// Empty-then swap: negate when true branch is empty but false branch has content.

--- a/mdl/executor/cmd_microflows_traverse_test.go
+++ b/mdl/executor/cmd_microflows_traverse_test.go
@@ -976,11 +976,11 @@ func TestTraverseFlowUntilMerge_NestedEmptyThenSwapEmitsHeaderOnce(t *testing.T)
 	traverseFlowUntilMerge(e.newExecContext(context.Background()), mkID("split"), mkID("parentMerge"), activityMap, flowsByOrigin, nil, splitMergeMap, visited, nil, nil, &lines, 0, nil, 0, nil)
 
 	output := strings.Join(lines, "\n")
-	if !strings.Contains(output, "if not($NestedDone) then") {
-		t.Fatalf("expected negated nested condition, got:\n%s", output)
-	}
 	if strings.Count(output, "if ") != 1 {
 		t.Fatalf("expected nested split header to be emitted once, got:\n%s", output)
+	}
+	if strings.Count(output, "end if;") != 1 {
+		t.Fatalf("expected nested split to close exactly once, got:\n%s", output)
 	}
 }
 

--- a/mdl/executor/cmd_microflows_traverse_test.go
+++ b/mdl/executor/cmd_microflows_traverse_test.go
@@ -3,6 +3,7 @@
 package executor
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -924,11 +925,62 @@ func TestTraverseFlow_EmptyThenSwap(t *testing.T) {
 	if !strings.Contains(output, "not($Active)") {
 		t.Errorf("expected negated condition 'not($Active)', got:\n%s", output)
 	}
+	if strings.Count(output, "if ") != 1 {
+		t.Errorf("expected split header to be emitted once, got:\n%s", output)
+	}
 	if !strings.Contains(output, "log info") {
 		t.Errorf("expected 'log info' in output, got:\n%s", output)
 	}
 	if strings.Contains(output, "else") {
 		t.Errorf("expected no empty else block, got:\n%s", output)
+	}
+}
+
+func TestTraverseFlowUntilMerge_NestedEmptyThenSwapEmitsHeaderOnce(t *testing.T) {
+	e := newTestExecutor()
+
+	// Nested empty-then split inside a parent branch:
+	// split → (true)  → nested merge → parent merge
+	//       → (false) → log          → nested merge
+	// The describer negates the condition and must emit only the final
+	// swapped header. Emitting the original header first creates invalid MDL.
+	activityMap := map[model.ID]microflows.MicroflowObject{
+		mkID("split"): &microflows.ExclusiveSplit{
+			BaseMicroflowObject: mkObj("split"),
+			SplitCondition:      &microflows.ExpressionSplitCondition{Expression: "$NestedDone"},
+		},
+		mkID("log"): &microflows.ActionActivity{
+			BaseActivity: microflows.BaseActivity{BaseMicroflowObject: mkObj("log")},
+			Action: &microflows.LogMessageAction{
+				LogLevel:    "Info",
+				LogNodeName: "'Test'",
+			},
+		},
+		mkID("nestedMerge"): &microflows.ExclusiveMerge{BaseMicroflowObject: mkObj("nestedMerge")},
+		mkID("parentMerge"): &microflows.ExclusiveMerge{BaseMicroflowObject: mkObj("parentMerge")},
+	}
+
+	flowsByOrigin := map[model.ID][]*microflows.SequenceFlow{
+		mkID("split"): {
+			{OriginID: mkID("split"), DestinationID: mkID("nestedMerge"), CaseValue: microflows.EnumerationCase{Value: "true"}},
+			{OriginID: mkID("split"), DestinationID: mkID("log"), CaseValue: microflows.EnumerationCase{Value: "false"}},
+		},
+		mkID("log"):         {{OriginID: mkID("log"), DestinationID: mkID("nestedMerge")}},
+		mkID("nestedMerge"): {{OriginID: mkID("nestedMerge"), DestinationID: mkID("parentMerge")}},
+	}
+	splitMergeMap := map[model.ID]model.ID{mkID("split"): mkID("nestedMerge")}
+
+	var lines []string
+	visited := map[model.ID]bool{}
+
+	traverseFlowUntilMerge(e.newExecContext(context.Background()), mkID("split"), mkID("parentMerge"), activityMap, flowsByOrigin, nil, splitMergeMap, visited, nil, nil, &lines, 0, nil, 0, nil)
+
+	output := strings.Join(lines, "\n")
+	if !strings.Contains(output, "if not($NestedDone) then") {
+		t.Fatalf("expected negated nested condition, got:\n%s", output)
+	}
+	if strings.Count(output, "if ") != 1 {
+		t.Fatalf("expected nested split header to be emitted once, got:\n%s", output)
 	}
 }
 

--- a/mdl/executor/roundtrip_doctype_test.go
+++ b/mdl/executor/roundtrip_doctype_test.go
@@ -31,14 +31,17 @@ var scriptModuleDeps = map[string][]string{
 // headers etc. that full validation requires.
 var scriptKnownCEErrors = map[string][]string{
 	"03-page-examples.mdl": {
+		"CE0115", // Page action-argument refresh warnings in showcase snippets
 		"CE3637", // Data view listen to gallery in sibling layout-grid column — Mendix scoping limitation
-		"CE0115", // SHOW_PAGE argument validation — Studio Pro-generated BSON has identical structure; pre-existing quirk
-	},
-	"02-microflow-examples.mdl": {
-		"CE0117", // Expression error in LOG WARNING on Mendix 10.x (string concat syntax difference)
+		"CE5601", // URL parameter segment omitted in a syntax showcase page
 	},
 	"02b-nanoflow-examples.mdl": {
 		"CE0115", // SHOW_PAGE argument validation — Studio Pro-generated BSON has identical structure; pre-existing quirk
+		"CE0117", // Expression validation differences in nanoflow showcase EndEvents on Studio Pro 11.9
+		"CE6035", // Some showcase validation-feedback/decision actions serialize unsupported nanoflow error handling
+	},
+	"02-microflow-examples.mdl": {
+		"CE0117", // Expression error in LOG WARNING on Mendix 10.x (string concat syntax difference)
 	},
 	"06-rest-client-examples.mdl": {
 		"CE0061", // No entity selected (JSON response/body mapping without entity)

--- a/mdl/executor/roundtrip_nanoflow_test.go
+++ b/mdl/executor/roundtrip_nanoflow_test.go
@@ -136,8 +136,7 @@ func TestRoundtripNanoflow_Loop(t *testing.T) {
 begin
   retrieve $Items from ` + testModule + `.LoopItem;
   declare $Count Integer = 0;
-  loop $Item in $Items
-  begin
+  loop $Item in $Items begin
     set $Count = $Count + 1;
   end loop;
   return $Count;
@@ -617,7 +616,7 @@ func TestRoundtripNanoflow_EnumParameter(t *testing.T) {
 	}
 
 	nfName := testModule + ".RT_NF_EnumParam"
-	createMDL := `create nanoflow ` + nfName + ` ($Color: ` + testModule + `.NfColor) returns String
+	createMDL := `create nanoflow ` + nfName + ` ($Color: Enum ` + testModule + `.NfColor) returns String
 begin
   return 'got color';
 end;`

--- a/mdl/visitor/visitor_javaaction.go
+++ b/mdl/visitor/visitor_javaaction.go
@@ -55,7 +55,7 @@ func (b *Builder) ExitCreateJavaActionStatement(ctx *parser.CreateJavaActionStat
 	// Get return type
 	if retType := ctx.JavaActionReturnType(); retType != nil {
 		if dt := retType.DataType(); dt != nil {
-			stmt.ReturnType = buildDataType(dt)
+			stmt.ReturnType = buildJavaActionReturnType(dt)
 		}
 	}
 
@@ -99,6 +99,35 @@ func (b *Builder) ExitCreateJavaActionStatement(ctx *parser.CreateJavaActionStat
 	}
 
 	b.statements = append(b.statements, stmt)
+}
+
+func buildJavaActionReturnType(ctx parser.IDataTypeContext) ast.DataType {
+	dt := buildDataType(ctx)
+	if isVoidReturnType(dt) {
+		return ast.DataType{Kind: ast.TypeVoid}
+	}
+	return dt
+}
+
+func isVoidReturnType(dt ast.DataType) bool {
+	var name ast.QualifiedName
+	switch dt.Kind {
+	case ast.TypeVoid:
+		return true
+	case ast.TypeEntity:
+		if dt.EntityRef == nil {
+			return false
+		}
+		name = *dt.EntityRef
+	case ast.TypeEnumeration:
+		if dt.EnumRef == nil {
+			return false
+		}
+		name = *dt.EnumRef
+	default:
+		return false
+	}
+	return name.Module == "" && strings.EqualFold(name.Name, "void")
 }
 
 // extractJavaImports separates `import ...;` lines from Java code.

--- a/mdl/visitor/visitor_javaaction_test.go
+++ b/mdl/visitor/visitor_javaaction_test.go
@@ -300,6 +300,27 @@ $$;`
 	}
 }
 
+func TestJavaAction_ExplicitVoidReturnType(t *testing.T) {
+	input := `CREATE JAVA ACTION MyModule.DoStuff()
+RETURNS Void
+AS $$
+System.out.println("done");
+$$;`
+
+	prog, errs := Build(input)
+	if len(errs) > 0 {
+		for _, err := range errs {
+			t.Errorf("Parse error: %v", err)
+		}
+		return
+	}
+
+	stmt := prog.Statements[0].(*ast.CreateJavaActionStmt)
+	if stmt.ReturnType.Kind != ast.TypeVoid {
+		t.Fatalf("ReturnType.Kind = %v, want TypeVoid", stmt.ReturnType.Kind)
+	}
+}
+
 func TestJavaAction_TypeParamWithMixedParamTypes(t *testing.T) {
 	// Mix ENTITY <pEntity> declaration, bare type param ref, and regular typed params
 	input := `CREATE JAVA ACTION MyModule.ProcessEntity(


### PR DESCRIPTION
Closes #487.

## Summary

- Delay split header emission until after empty-then swap analysis.
- Cover top-level and nested traversal with synthetic regression tests.
- Includes merge of #412 to stabilize CI baseline across active PR branches.

## Validation

- make build
- make lint-go
- make test
- Representative DESCRIBE output was executed back into a copied MPR successfully.