### PR TITLE
fix: scope duplicate output checks by branch path

### DIFF
--- a/mdl/executor/cmd_microflows_builder_validate.go
+++ b/mdl/executor/cmd_microflows_builder_validate.go
@@ -67,6 +67,14 @@ func (fb *flowBuilder) validateStatements(stmts []ast.MicroflowStatement) {
 	}
 }
 
+func (fb *flowBuilder) validateScopedStatements(stmts []ast.MicroflowStatement) {
+	scoped := *fb
+	scoped.varTypes = cloneStringMap(fb.varTypes)
+	scoped.declaredVars = cloneStringMap(fb.declaredVars)
+	scoped.validateStatements(stmts)
+	fb.errors = scoped.errors
+}
+
 // validateStatement validates a single statement for semantic errors.
 func (fb *flowBuilder) validateStatement(stmt ast.MicroflowStatement) {
 	switch s := stmt.(type) {
@@ -93,19 +101,17 @@ func (fb *flowBuilder) validateStatement(stmt ast.MicroflowStatement) {
 		}
 
 	case *ast.IfStmt:
-		// Validate then branch
-		fb.validateStatements(s.ThenBody)
-		// Validate else branch if present
+		fb.validateScopedStatements(s.ThenBody)
 		if len(s.ElseBody) > 0 {
-			fb.validateStatements(s.ElseBody)
+			fb.validateScopedStatements(s.ElseBody)
 		}
 
 	case *ast.EnumSplitStmt:
 		for _, c := range s.Cases {
-			fb.validateStatements(c.Body)
+			fb.validateScopedStatements(c.Body)
 		}
 		if len(s.ElseBody) > 0 {
-			fb.validateStatements(s.ElseBody)
+			fb.validateScopedStatements(s.ElseBody)
 		}
 
 	case *ast.LoopStmt:

--- a/mdl/executor/cmd_microflows_duplicate_output_test.go
+++ b/mdl/executor/cmd_microflows_duplicate_output_test.go
@@ -59,6 +59,68 @@ func TestValidateMicroflowBodyRejectsDuplicateCallOutputs(t *testing.T) {
 	}
 }
 
+func TestValidateMicroflowBodyAllowsDuplicateOutputsInExclusiveBranches(t *testing.T) {
+	entityRef := ast.QualifiedName{Module: "Synthetic", Name: "Item"}
+	stmt := &ast.CreateMicroflowStmt{
+		Body: []ast.MicroflowStatement{
+			&ast.IfStmt{
+				Condition: &ast.VariableExpr{Name: "UsePrimaryPath"},
+				ThenBody: []ast.MicroflowStatement{
+					&ast.CreateObjectStmt{Variable: "Result", EntityType: entityRef},
+					&ast.ReturnStmt{},
+				},
+				ElseBody: []ast.MicroflowStatement{
+					&ast.RetrieveStmt{Variable: "Result", Source: entityRef, Limit: "1"},
+					&ast.ReturnStmt{},
+				},
+			},
+		},
+	}
+
+	errs := ValidateMicroflowBody(stmt)
+	for _, err := range errs {
+		if strings.Contains(err, "duplicate variable name '$Result'") {
+			t.Fatalf("exclusive branches must not share duplicate-output scope: %#v", errs)
+		}
+	}
+}
+
+func TestValidateMicroflowBodyAllowsDuplicateOutputsInEnumCases(t *testing.T) {
+	entityRef := ast.QualifiedName{Module: "Synthetic", Name: "Item"}
+	stmt := &ast.CreateMicroflowStmt{
+		Body: []ast.MicroflowStatement{
+			&ast.EnumSplitStmt{
+				Variable: "Route",
+				Cases: []ast.EnumSplitCase{
+					{
+						Value: "First",
+						Body: []ast.MicroflowStatement{
+							&ast.CallJavaActionStmt{OutputVariable: "GeneratedID", ActionName: ast.QualifiedName{Module: "Synthetic", Name: "Generate"}},
+							&ast.CreateObjectStmt{Variable: "Result", EntityType: entityRef},
+							&ast.ReturnStmt{},
+						},
+					},
+					{
+						Value: "Second",
+						Body: []ast.MicroflowStatement{
+							&ast.CallJavaActionStmt{OutputVariable: "GeneratedID", ActionName: ast.QualifiedName{Module: "Synthetic", Name: "Generate"}},
+							&ast.CreateObjectStmt{Variable: "Result", EntityType: entityRef},
+							&ast.ReturnStmt{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	errs := strings.Join(ValidateMicroflowBody(stmt), "\n")
+	for _, name := range []string{"GeneratedID", "Result"} {
+		if strings.Contains(errs, "duplicate variable name '$"+name+"'") {
+			t.Fatalf("enum cases must not share duplicate-output scope: %s", errs)
+		}
+	}
+}
+
 func TestFormatMicroflowActivitiesWarnsAboutDuplicateModelOutputs(t *testing.T) {
 	oc := &microflows.MicroflowObjectCollection{
 		Objects: []microflows.MicroflowObject{
@@ -107,5 +169,73 @@ func TestFormatMicroflowActivitiesWarnsAboutDuplicateModelOutputs(t *testing.T) 
 	}
 	if strings.Contains(got, "$Item_2") {
 		t.Fatalf("describe output must not invent aliases:\n%s", got)
+	}
+}
+
+func TestFormatMicroflowActivitiesDoesNotWarnForExclusiveBranchOutputs(t *testing.T) {
+	oc := &microflows.MicroflowObjectCollection{
+		Objects: []microflows.MicroflowObject{
+			&microflows.StartEvent{
+				BaseMicroflowObject: microflows.BaseMicroflowObject{
+					BaseElement: model.BaseElement{ID: "start"},
+					Position:    model.Point{X: 0, Y: 100},
+				},
+			},
+			&microflows.ExclusiveSplit{
+				BaseMicroflowObject: microflows.BaseMicroflowObject{
+					BaseElement: model.BaseElement{ID: "split"},
+					Position:    model.Point{X: 100, Y: 100},
+				},
+				SplitCondition: &microflows.ExpressionSplitCondition{Expression: "$UsePrimaryPath"},
+			},
+			&microflows.ActionActivity{
+				BaseActivity: microflows.BaseActivity{
+					BaseMicroflowObject: microflows.BaseMicroflowObject{
+						BaseElement: model.BaseElement{ID: "then_create"},
+						Position:    model.Point{X: 200, Y: 100},
+					},
+				},
+				Action: &microflows.CreateObjectAction{OutputVariable: "Result", EntityQualifiedName: "Synthetic.Item"},
+			},
+			&microflows.ActionActivity{
+				BaseActivity: microflows.BaseActivity{
+					BaseMicroflowObject: microflows.BaseMicroflowObject{
+						BaseElement: model.BaseElement{ID: "else_retrieve"},
+						Position:    model.Point{X: 200, Y: 200},
+					},
+				},
+				Action: &microflows.RetrieveAction{
+					OutputVariable: "Result",
+					Source: &microflows.DatabaseRetrieveSource{
+						EntityQualifiedName: "Synthetic.Item",
+					},
+				},
+			},
+			&microflows.EndEvent{
+				BaseMicroflowObject: microflows.BaseMicroflowObject{
+					BaseElement: model.BaseElement{ID: "then_end"},
+					Position:    model.Point{X: 300, Y: 100},
+				},
+			},
+			&microflows.EndEvent{
+				BaseMicroflowObject: microflows.BaseMicroflowObject{
+					BaseElement: model.BaseElement{ID: "else_end"},
+					Position:    model.Point{X: 300, Y: 200},
+				},
+			},
+		},
+		Flows: []*microflows.SequenceFlow{
+			{OriginID: "start", DestinationID: "split"},
+			{OriginID: "split", DestinationID: "then_create", CaseValue: &microflows.ExpressionCase{Expression: "true"}},
+			{OriginID: "split", DestinationID: "else_retrieve", CaseValue: &microflows.ExpressionCase{Expression: "false"}},
+			{OriginID: "then_create", DestinationID: "then_end"},
+			{OriginID: "else_retrieve", DestinationID: "else_end"},
+		},
+	}
+	lines := formatMicroflowActivities(&ExecContext{}, &microflows.Microflow{ObjectCollection: oc}, nil, nil)
+	got := strings.Join(lines, "\n")
+
+	if strings.Contains(got, "-- WARNING: duplicate output variable $Result") {
+		t.Fatalf("exclusive branch outputs must not be warned as linear duplicates:\n%s", got)
 	}
 }

--- a/mdl/executor/cmd_microflows_show.go
+++ b/mdl/executor/cmd_microflows_show.go
@@ -783,53 +783,108 @@ func formatMicroflowActivities(
 	return lines
 }
 
+type outputVariableSeen struct {
+	pos model.Point
+}
+
 func duplicateOutputVariableWarnings(oc *microflows.MicroflowObjectCollection) []string {
-	type occurrence struct {
-		variable string
-		pos      model.Point
-	}
-	var occurrences []occurrence
-	var walk func(*microflows.MicroflowObjectCollection)
-	walk = func(collection *microflows.MicroflowObjectCollection) {
+	warningPositions := make(map[string]model.Point)
+
+	var walkCollection func(*microflows.MicroflowObjectCollection, map[string]outputVariableSeen)
+	walkCollection = func(collection *microflows.MicroflowObjectCollection, inherited map[string]outputVariableSeen) {
 		if collection == nil {
 			return
 		}
+		activityMap := make(map[model.ID]microflows.MicroflowObject)
+		flowsByOrigin := make(map[model.ID][]*microflows.SequenceFlow)
+		var starts []model.ID
 		for _, obj := range collection.Objects {
+			activityMap[obj.GetID()] = obj
+			if _, ok := obj.(*microflows.StartEvent); ok {
+				starts = append(starts, obj.GetID())
+			}
+		}
+		for _, flow := range collection.Flows {
+			flowsByOrigin[flow.OriginID] = append(flowsByOrigin[flow.OriginID], flow)
+		}
+		if len(starts) == 0 {
+			for _, obj := range collection.Objects {
+				starts = append(starts, obj.GetID())
+			}
+		}
+
+		var walkNode func(model.ID, map[string]outputVariableSeen, map[model.ID]bool)
+		walkNode = func(currentID model.ID, seen map[string]outputVariableSeen, path map[model.ID]bool) {
+			if currentID == "" || path[currentID] {
+				return
+			}
+			obj := activityMap[currentID]
+			if obj == nil {
+				return
+			}
+			path = cloneIDBoolMap(path)
+			path[currentID] = true
+			seen = cloneSeenOutputs(seen)
+
 			if activity, ok := obj.(*microflows.ActionActivity); ok {
 				if name := actionOutputVariableName(activity.Action); name != "" {
-					occurrences = append(occurrences, occurrence{variable: name, pos: obj.GetPosition()})
+					if first, ok := seen[name]; ok {
+						if _, recorded := warningPositions[name]; !recorded {
+							warningPositions[name] = first.pos
+						}
+					} else {
+						seen[name] = outputVariableSeen{pos: obj.GetPosition()}
+					}
 				}
 			}
 			if loop, ok := obj.(*microflows.LoopedActivity); ok {
-				walk(loop.ObjectCollection)
+				walkCollection(loop.ObjectCollection, seen)
+			}
+			for _, flow := range findNormalFlows(flowsByOrigin[currentID]) {
+				walkNode(flow.DestinationID, seen, path)
 			}
 		}
-	}
-	walk(oc)
 
-	counts := make(map[string]int)
-	firstPos := make(map[string]model.Point)
-	for _, occ := range occurrences {
-		counts[occ.variable]++
-		if _, ok := firstPos[occ.variable]; !ok {
-			firstPos[occ.variable] = occ.pos
+		for _, startID := range starts {
+			walkNode(startID, cloneSeenOutputs(inherited), nil)
 		}
 	}
+	walkCollection(oc, nil)
 
 	var names []string
-	for name, count := range counts {
-		if count > 1 {
-			names = append(names, name)
-		}
+	for name := range warningPositions {
+		names = append(names, name)
 	}
 	sort.Strings(names)
 
 	warnings := make([]string, 0, len(names))
 	for _, name := range names {
-		pos := firstPos[name]
+		pos := warningPositions[name]
 		warnings = append(warnings, fmt.Sprintf("-- WARNING: duplicate output variable $%s at position (%d, %d) - model is invalid; open in Studio Pro to fix", name, pos.X, pos.Y))
 	}
 	return warnings
+}
+
+func cloneSeenOutputs(src map[string]outputVariableSeen) map[string]outputVariableSeen {
+	if src == nil {
+		return make(map[string]outputVariableSeen)
+	}
+	dst := make(map[string]outputVariableSeen, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func cloneIDBoolMap(src map[model.ID]bool) map[model.ID]bool {
+	if src == nil {
+		return make(map[model.ID]bool)
+	}
+	dst := make(map[model.ID]bool, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }
 
 func actionOutputVariableName(action any) string {


### PR DESCRIPTION
Closes #489.

## Summary

- validate IF and enum-split branch bodies with cloned output-variable scopes
- make duplicate-output DESCRIBE warnings track variables per normal sequence-flow path
- keep linear duplicate-output errors/warnings intact while avoiding false positives for mutually exclusive branches

## Validation

- make build
- make test
- make lint-go