### PR TITLE
fix: parse negative annotation coordinates

### DIFF
--- a/mdl/visitor/visitor_entity.go
+++ b/mdl/visitor/visitor_entity.go
@@ -497,6 +497,9 @@ func parseAnnotationParamInt(ctx parser.IAnnotationParamContext) int {
 	}
 	paramCtx := ctx.(*parser.AnnotationParamContext)
 	if valueCtx := paramCtx.AnnotationValue(); valueCtx != nil {
+		if val, err := strconv.Atoi(strings.TrimSpace(valueCtx.GetText())); err == nil {
+			return val
+		}
 		annValue := valueCtx.(*parser.AnnotationValueContext)
 		if lit := annValue.Literal(); lit != nil {
 			litCtx := lit.(*parser.LiteralContext)

--- a/mdl/visitor/visitor_test.go
+++ b/mdl/visitor/visitor_test.go
@@ -1804,6 +1804,31 @@ END;`
 	}
 }
 
+func TestMicroflowPositionAnnotationAcceptsNegativeCoordinates(t *testing.T) {
+	input := `CREATE MICROFLOW Synthetic.Check ()
+BEGIN
+  @position(-150, -210)
+  LOG INFO NODE 'SyntheticLog' 'message';
+END;`
+
+	prog, errs := Build(input)
+	if len(errs) > 0 {
+		t.Fatalf("unexpected parse errors: %v", errs)
+	}
+
+	stmt := prog.Statements[0].(*ast.CreateMicroflowStmt)
+	logStmt, ok := stmt.Body[0].(*ast.LogStmt)
+	if !ok {
+		t.Fatalf("Expected LogStmt, got %T", stmt.Body[0])
+	}
+	if logStmt.Annotations == nil || logStmt.Annotations.Position == nil {
+		t.Fatal("expected position annotation")
+	}
+	if got := *logStmt.Annotations.Position; got.X != -150 || got.Y != -210 {
+		t.Fatalf("position = (%d, %d), want (-150, -210)", got.X, got.Y)
+	}
+}
+
 func TestCallJavaActionAcceptsEmptyArguments(t *testing.T) {
 	input := `CREATE MICROFLOW Synthetic.Check ()
 RETURNS Boolean AS $Success


### PR DESCRIPTION
Closes #493.

## Summary

- preserves signed integer values in annotation parameters such as `@position(-150, -210)`
- keeps the existing literal-only fallback for non-signed numeric annotation parameters
- adds a synthetic microflow visitor regression test for negative coordinates

## Validation

- `go test ./mdl/visitor -run 'NegativeCoordinates|PositionAnnotation' -v`
- `make build`
- `make lint-go`
- `make test`