### PR TITLE
fix: preserve cross-module associations on CREATE object actions

### DIFF
--- a/mdl/executor/cmd_microflows_builder_actions.go
+++ b/mdl/executor/cmd_microflows_builder_actions.go
@@ -1187,20 +1187,29 @@ func (fb *flowBuilder) resolveMemberChange(mc *microflows.MemberChange, memberNa
 	}
 	moduleName := parts[0]
 
-	// If memberName is already qualified (e.g., "MfTest.Order_Customer"),
-	// extract the bare name for association lookup.
+	// If memberName is already qualified (e.g., "Module.Assoc"), the qualifier
+	// is the module that OWNS the association, not the create/change target's
+	// module. Associations can live in any module (see cross-association
+	// lookups below), so prefer the authored module when present.
 	bareName := memberName
 	qualifiedName := memberName
+	lookupModule := moduleName
 	if dot := strings.Index(memberName, "."); dot >= 0 {
+		lookupModule = memberName[:dot]
 		bareName = memberName[dot+1:]
 		// qualifiedName is already set to the full memberName
 	} else {
 		qualifiedName = moduleName + "." + memberName
 	}
 
-	// Query domain model to check if this member is an association
+	// Query the authored (or target) module's domain model first. When the
+	// association actually lives in a different module — the common case for
+	// cross-module associations like `OtherModule.Assoc_Name` on a
+	// `TargetModule.Entity` entity — keep the qualified name so the writer
+	// serialises `Association` correctly instead of falling back to
+	// `Attribute` and triggering Studio Pro CE1613 on re-open.
 	if fb.backend != nil {
-		if mod, err := fb.backend.GetModuleByName(moduleName); err == nil && mod != nil {
+		if mod, err := fb.backend.GetModuleByName(lookupModule); err == nil && mod != nil {
 			if dm, err := fb.backend.GetDomainModel(mod.ID); err == nil && dm != nil {
 				for _, a := range dm.Associations {
 					if a.Name == bareName {
@@ -1214,9 +1223,11 @@ func (fb *flowBuilder) resolveMemberChange(mc *microflows.MemberChange, memberNa
 						return
 					}
 				}
-				// Not an association — it's an attribute
+				// Not an association in the authored module — if the author
+				// qualified it (e.g. `Module.Attr`) the qualification is an
+				// error we must preserve rather than silently dropping; the
+				// writer will surface it during mx check.
 				if strings.Contains(memberName, ".") {
-					// Already qualified, don't double-qualify
 					mc.AttributeQualifiedName = memberName
 				} else if attrQN, ok := fb.resolveAttributeInEntityHierarchy(entityQN, memberName); ok {
 					mc.AttributeQualifiedName = attrQN

--- a/mdl/executor/cmd_microflows_create_cross_module_assoc_test.go
+++ b/mdl/executor/cmd_microflows_create_cross_module_assoc_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/mendixlabs/mxcli/mdl/backend/mock"
+	"github.com/mendixlabs/mxcli/model"
+	"github.com/mendixlabs/mxcli/sdk/domainmodel"
+	"github.com/mendixlabs/mxcli/sdk/microflows"
+)
+
+// TestResolveMemberChange_CrossModuleAssociationKeepsAssociationSlot guards
+// against describe → exec → describe dropping cross-module associations into
+// the Attribute slot on CREATE/CHANGE actions. A CREATE
+// `TargetMod.Entity (OwnerMod.Assoc = $Ref)` refers to an association whose
+// owning module (`OwnerMod`) is not the create target's module
+// (`TargetMod`). Before the fix the resolver only looked up the target's
+// module, failed to find the association, and fell through to
+// `AttributeQualifiedName`, causing Studio Pro to raise CE1613 "selected
+// attribute no longer exists" on the re-opened MPR.
+func TestResolveMemberChange_CrossModuleAssociationKeepsAssociationSlot(t *testing.T) {
+	brandModuleID := model.ID("synthetic-brand-module")
+	ownerModuleID := model.ID("synthetic-owner-module")
+
+	backend := &mock.MockBackend{
+		GetModuleByNameFunc: func(name string) (*model.Module, error) {
+			switch name {
+			case "SyntheticBrand":
+				return &model.Module{BaseElement: model.BaseElement{ID: brandModuleID}, Name: name}, nil
+			case "SyntheticOwner":
+				return &model.Module{BaseElement: model.BaseElement{ID: ownerModuleID}, Name: name}, nil
+			}
+			return nil, nil
+		},
+		GetDomainModelFunc: func(id model.ID) (*domainmodel.DomainModel, error) {
+			switch id {
+			case brandModuleID:
+				return &domainmodel.DomainModel{
+					ContainerID: brandModuleID,
+					Entities: []*domainmodel.Entity{
+						{Name: "Brand"},
+					},
+				}, nil
+			case ownerModuleID:
+				return &domainmodel.DomainModel{
+					ContainerID: ownerModuleID,
+					Associations: []*domainmodel.Association{
+						{Name: "Company_Brand", Type: domainmodel.AssociationTypeReference},
+					},
+				}, nil
+			}
+			return nil, nil
+		},
+	}
+
+	fb := &flowBuilder{backend: backend}
+	var mc microflows.MemberChange
+	fb.resolveMemberChange(&mc, "SyntheticOwner.Company_Brand", "SyntheticBrand.Brand")
+
+	if mc.AssociationQualifiedName != "SyntheticOwner.Company_Brand" {
+		t.Errorf("AssociationQualifiedName = %q, want %q — cross-module association dropped",
+			mc.AssociationQualifiedName, "SyntheticOwner.Company_Brand")
+	}
+	if mc.AttributeQualifiedName != "" {
+		t.Errorf("AttributeQualifiedName = %q, want empty — association leaked into attribute slot",
+			mc.AttributeQualifiedName)
+	}
+}

--- a/mdl/executor/cmd_microflows_format_action.go
+++ b/mdl/executor/cmd_microflows_format_action.go
@@ -193,14 +193,29 @@ func formatAction(
 
 		if len(a.InitialMembers) > 0 {
 			var members []string
+			// entityModule is the module of the create target (e.g. "TargetModule"
+			// for `create TargetModule.Entity`). Associations in other modules
+			// must keep their module prefix so the re-exec resolver finds them.
+			entityModule := ""
+			if parts := strings.SplitN(entityName, ".", 2); len(parts) == 2 {
+				entityModule = parts[0]
+			}
 			for _, m := range a.InitialMembers {
 				var memberName string
 				// Check if this is an association change or an attribute change
 				if m.AssociationQualifiedName != "" {
-					// Association: extract just the association name
+					// Association: keep the module prefix when the association
+					// is defined in a different module than the create target.
+					// The authored form `Module.Assoc` is preserved so re-exec
+					// resolves against the association's owning module rather
+					// than defaulting to the create target's module, which
+					// would cause Studio Pro CE1613 "attribute no longer exists"
+					// at re-open.
 					memberName = m.AssociationQualifiedName
-					if parts := strings.Split(memberName, "."); len(parts) > 0 {
-						memberName = parts[len(parts)-1]
+					if parts := strings.SplitN(memberName, ".", 2); len(parts) == 2 {
+						if parts[0] == entityModule {
+							memberName = parts[1]
+						}
 					}
 				} else {
 					// Attribute: extract just the attribute name


### PR DESCRIPTION
Part of #352.

## Summary

- A `create TargetMod.Entity (OwnerMod.Assoc = \$Ref)` statement round-tripped as an attribute assignment when the association lived in a different module than the create target.
- **Describer side**: `formatAction` on `CreateObjectAction` stripped every association member down to its bare name, losing the cross-module qualifier.
- **Builder side**: `resolveMemberChange` queried the create target's module for the bare name, didn't find the association, and fell through to `AttributeQualifiedName` — triggering Studio Pro **CE1613** ("selected attribute no longer exists") on re-open.

## Fix

1. Describer keeps the `Module.` prefix on any association whose owning module differs from the create target's module.
2. Builder uses the authored module (when the member name is qualified) to look up the association, matching how the describer expresses it.

## Test plan

- [x] New unit test `TestResolveMemberChange_CrossModuleAssociationKeepsAssociationSlot` verifies the association lands on `AssociationQualifiedName` (not the attribute slot) with synthetic module names.
- [x] `go build -tags integration ./...` builds clean.
- [x] `go test ./mdl/executor/ -count=1` passes.
- [ ] Validated in Mendix Studio Pro with \`mx check\` on a local project where a \`CREATE\` assigns a cross-module association — CE1613 no longer reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)