### PR TITLE
fix: rejoin empty error handler at IF split when next IF reads skipVar

### DIFF
--- a/mdl/executor/cmd_microflows_builder_flows.go
+++ b/mdl/executor/cmd_microflows_builder_flows.go
@@ -184,6 +184,18 @@ func (fb *flowBuilder) addPendingErrorHandlerFlowForState(state pendingErrorHand
 	}
 	if state.skipVar != "" {
 		if statementReferencesVar(stmt, state.skipVar) {
+			// An IF whose condition reads the skipVar itself handles the
+			// empty/error case in its own branches (e.g. `if $Response !=
+			// empty and $Response/StatusCode < 400 then … else <fallback>`).
+			// The original Mendix flow in these cases routes the error-
+			// handler edge directly into the IF's split, reusing the
+			// fallback path. Re-using the split as the rejoin point avoids
+			// the phantom EndEvent that terminatePendingErrorHandlersAtEnd
+			// would otherwise create when both IF branches terminate.
+			if _, ok := stmt.(*ast.IfStmt); ok {
+				fb.addErrorHandlerRejoinFlowForState(state, originID, destinationID)
+				return pendingErrorHandlerState{}
+			}
 			if !fb.hasDeclaredReturnValue() {
 				if derivedVar := outputDerivedVariable(stmt, state.skipVar); derivedVar != "" {
 					state.skipVar = derivedVar

--- a/mdl/executor/cmd_microflows_empty_handler_if_rejoin_test.go
+++ b/mdl/executor/cmd_microflows_empty_handler_if_rejoin_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/mendixlabs/mxcli/mdl/ast"
+	"github.com/mendixlabs/mxcli/model"
+	"github.com/mendixlabs/mxcli/sdk/microflows"
+)
+
+// TestEmptyErrorHandlerFollowedByBothReturnIfRejoinsAtIfSplit reproduces the
+// shape where a call action with an empty custom error handler (
+// `$Var = call microflow ... on error without rollback { };`) is followed
+// by an IF that tests $Var and whose branches both RETURN. Before the fix
+// the builder produced a phantom EndEvent at the microflow tail because
+// the pending error-handler rejoin skipped past the IF (the IF references
+// the skipVar so the heuristic refused to reuse it), then
+// terminatePendingErrorHandlersAtEnd created its own terminator.
+//
+// The fix: when the statement that references the skipVar is itself an
+// IfStmt, rejoin the error-handler edge directly at the IF's split. The
+// IF's condition already handles the empty/error case in its fallback
+// branch, so re-using the split matches the Studio Pro source graph.
+func TestEmptyErrorHandlerFollowedByBothReturnIfRejoinsAtIfSplit(t *testing.T) {
+	fb := &flowBuilder{
+		spacing:      HorizontalSpacing,
+		measurer:     &layoutMeasurer{},
+		declaredVars: map[string]string{"R": "String"},
+	}
+
+	oc := fb.buildFlowGraph([]ast.MicroflowStatement{
+		&ast.CallMicroflowStmt{
+			MicroflowName:  ast.QualifiedName{Module: "M", Name: "Helper"},
+			OutputVariable: "R",
+			ErrorHandling: &ast.ErrorHandlingClause{
+				Type: ast.ErrorHandlingCustomWithoutRollback,
+				Body: nil,
+			},
+		},
+		&ast.IfStmt{
+			Condition: &ast.VariableExpr{Name: "R"},
+			ThenBody:  []ast.MicroflowStatement{&ast.ReturnStmt{}},
+			ElseBody:  []ast.MicroflowStatement{&ast.ReturnStmt{}},
+		},
+	}, nil)
+
+	endEvents := 0
+	for _, obj := range oc.Objects {
+		if _, ok := obj.(*microflows.EndEvent); ok {
+			endEvents++
+		}
+	}
+	// Expected: 2 EndEvents (one per IF branch). The phantom
+	// terminatePendingErrorHandlersAtEnd EndEvent should NOT be created.
+	if endEvents != 2 {
+		t.Errorf("got %d EndEvents, want 2 — phantom EndEvent from empty handler at microflow end", endEvents)
+	}
+
+	// The error-handler flow from the call activity must reach the IF
+	// split (possibly through a rejoin merge), not a standalone EndEvent.
+	var callID, ifSplitID model.ID
+	for _, obj := range oc.Objects {
+		switch o := obj.(type) {
+		case *microflows.ActionActivity:
+			if _, ok := o.Action.(*microflows.MicroflowCallAction); ok {
+				callID = o.ID
+			}
+		case *microflows.ExclusiveSplit:
+			ifSplitID = o.ID
+		}
+	}
+	if callID == "" || ifSplitID == "" {
+		t.Fatal("missing call activity or if split")
+	}
+	// Walk the error flow from callID; it should reach ifSplitID through
+	// zero or more ExclusiveMerge hops.
+	errorFlows := map[model.ID][]*microflows.SequenceFlow{}
+	for _, f := range oc.Flows {
+		errorFlows[f.OriginID] = append(errorFlows[f.OriginID], f)
+	}
+	reachesIf := false
+	var walk func(id model.ID, depth int)
+	walk = func(id model.ID, depth int) {
+		if depth > 5 {
+			return
+		}
+		if id == ifSplitID {
+			reachesIf = true
+			return
+		}
+		for _, f := range errorFlows[id] {
+			walk(f.DestinationID, depth+1)
+		}
+	}
+	for _, f := range errorFlows[callID] {
+		if !f.IsErrorHandler {
+			continue
+		}
+		walk(f.DestinationID, 0)
+	}
+	if !reachesIf {
+		t.Error("error-handler edge from call did not reach the IF split")
+	}
+}


### PR DESCRIPTION
## Summary

- When a call action with an output variable had \`on error without rollback { }\` and the following statement was an IF whose condition read that output variable, the builder queued the handler as pending and never rejoined it.
- If both IF branches terminated (both RETURN), the microflow-end terminator then created a **phantom EndEvent** for the un-rejoined handler. Re-describe then surfaced an extra \`return;\` inside the empty handler body, producing a semantic difference between the original and re-executed MPR.
- The authored Mendix pattern wires the error edge into the IF's split: the IF's own \`empty\` / status-code guard in the condition is what handles the error case, and the ELSE branch already contains the fallback path.

## Fix

Narrow change in \`addPendingErrorHandlerFlowForState\`: when \`state.skipVar\` is set and the next statement references it **and** is an \`*ast.IfStmt\`, rejoin at the IF split instead of deferring the handler. Non-IF statements keep the existing deferral semantics.

## Test plan

- [x] \`go test ./mdl/executor/ -count=1\` passes
- [x] \`go build -tags integration ./...\` builds clean
- [x] New unit test \`TestEmptyErrorHandlerFollowedByBothReturnIfRejoinsAtIfSplit\` asserts the error edge from the call reaches the IF split and the microflow ends with exactly 2 EndEvents (no phantom).
- [ ] Validated in Mendix Studio Pro against a local project — \`mx check\` clean on the microflow that originally surfaced this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)