### PR TITLE
fix: skip System.* references in `mxcli check --references`

### DIFF
--- a/mdl/executor/validate.go
+++ b/mdl/executor/validate.go
@@ -478,6 +478,14 @@ func validateFlowBodyReferences(ctx *ExecContext, body []ast.MicroflowStatement,
 	if len(refs.javaActions) > 0 {
 		known := buildJavaActionQualifiedNames(ctx)
 		for _, ref := range refs.javaActions {
+			// System.* Java actions (e.g. System.VerifyPassword,
+			// System.GenerateRandomString) are runtime-provided and never
+			// appear in the project's MPR. Skip them to avoid false
+			// positives — Studio Pro's `mx check` resolves these against
+			// the runtime, which `mxcli check` cannot reach.
+			if isBuiltinModuleEntity(qualifiedNameModule(ref)) {
+				continue
+			}
 			if !known[ref] {
 				errors = append(errors, fmt.Sprintf("java action not found: %s (referenced by call java action)", ref))
 			}
@@ -487,6 +495,9 @@ func validateFlowBodyReferences(ctx *ExecContext, body []ast.MicroflowStatement,
 	if len(refs.javaScriptActions) > 0 {
 		known := buildJavaScriptActionQualifiedNames(ctx)
 		for _, ref := range refs.javaScriptActions {
+			if isBuiltinModuleEntity(qualifiedNameModule(ref)) {
+				continue
+			}
 			if !known[ref] {
 				errors = append(errors, fmt.Sprintf("javascript action not found: %s (referenced by call javascript action)", ref))
 			}
@@ -503,6 +514,15 @@ func validateFlowBodyReferences(ctx *ExecContext, body []ast.MicroflowStatement,
 	}
 
 	return errors
+}
+
+// qualifiedNameModule returns the module portion of a "Module.Name" qualified
+// name. It returns an empty string when the input has no dot.
+func qualifiedNameModule(qn string) string {
+	if i := strings.Index(qn, "."); i >= 0 {
+		return qn[:i]
+	}
+	return ""
 }
 
 // flowRefCollector collects qualified name references from flow body statements.

--- a/mdl/executor/validate_system_javaaction_test.go
+++ b/mdl/executor/validate_system_javaaction_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mendixlabs/mxcli/mdl/ast"
+	"github.com/mendixlabs/mxcli/mdl/backend/mock"
+	"github.com/mendixlabs/mxcli/model"
+	"github.com/mendixlabs/mxcli/sdk/javaactions"
+	"github.com/mendixlabs/mxcli/sdk/microflows"
+)
+
+// `mxcli check --references` must not flag System.* Java actions
+// (System.VerifyPassword, System.GenerateRandomString, etc.) as missing.
+// They are runtime-provided and never appear in the project MPR; flagging
+// them produces false positives on any microflow that uses Mendix
+// built-ins, including the Administration module's password flows.
+func TestValidateMicroflowReferencesSkipsSystemJavaAction(t *testing.T) {
+	moduleID := model.ID("module-1")
+	backend := &mock.MockBackend{
+		IsConnectedFunc: func() bool { return true },
+		ListModulesFunc: func() ([]*model.Module, error) {
+			return []*model.Module{{
+				BaseElement: model.BaseElement{ID: moduleID},
+				Name:        "Administration",
+			}}, nil
+		},
+		ListMicroflowsFunc: func() ([]*microflows.Microflow, error) {
+			return nil, nil
+		},
+		ListJavaActionsFunc: nil,
+	}
+	ctx, _ := newMockCtx(t, withBackend(backend))
+
+	stmt := &ast.CreateMicroflowStmt{
+		Name: ast.QualifiedName{Module: "Administration", Name: "ChangeMyPassword"},
+		Body: []ast.MicroflowStatement{
+			&ast.CallJavaActionStmt{
+				ActionName: ast.QualifiedName{Module: "System", Name: "VerifyPassword"},
+			},
+		},
+	}
+
+	if err := validate(ctx, stmt); err != nil {
+		t.Fatalf("System.* Java action reference must not error, got: %v", err)
+	}
+}
+
+// User-module Java action references are still validated. A missing one
+// must error out so genuine typos don't slip through.
+func TestValidateMicroflowReferencesReportsMissingUserJavaAction(t *testing.T) {
+	moduleID := model.ID("module-1")
+	backend := &mock.MockBackend{
+		IsConnectedFunc: func() bool { return true },
+		ListModulesFunc: func() ([]*model.Module, error) {
+			return []*model.Module{{
+				BaseElement: model.BaseElement{ID: moduleID},
+				Name:        "Administration",
+			}}, nil
+		},
+		ListMicroflowsFunc: func() ([]*microflows.Microflow, error) {
+			return nil, nil
+		},
+		ListJavaActionsFunc: nil,
+		ReadJavaActionByNameFunc: func(qn string) (*javaactions.JavaAction, error) {
+			return nil, nil
+		},
+	}
+	ctx, _ := newMockCtx(t, withBackend(backend))
+
+	stmt := &ast.CreateMicroflowStmt{
+		Name: ast.QualifiedName{Module: "Administration", Name: "BadCall"},
+		Body: []ast.MicroflowStatement{
+			&ast.CallJavaActionStmt{
+				ActionName: ast.QualifiedName{Module: "Administration", Name: "NonExistentJavaAction"},
+			},
+		},
+	}
+
+	err := validate(ctx, stmt)
+	if err == nil {
+		t.Fatal("expected missing user Java action reference error")
+	}
+	if !strings.Contains(err.Error(), "java action not found: Administration.NonExistentJavaAction") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`mxcli check --references` reports `java action not found: System.VerifyPassword` (and similar) on any microflow that calls a Mendix runtime built-in. The validator listed only Java actions found in the project's MPR; System-module actions are runtime-provided and never appear in the MPR.

Studio Pro's `mx check` resolves them against the runtime, so they pass there — but `mxcli check --references` cannot reach the runtime and produced false positives on built-in calls (`System.VerifyPassword`, `System.GenerateRandomString`, `System.SubMicroflow*`, etc.).

Skip Java/JavaScript action references whose qualified name starts with the `System` module — the same pattern (`isBuiltinModuleEntity`) already guards entity references in `cmd_microflows_create.go` and `cmd_nanoflows_create.go`.

## Reproduction

Any MPR with a microflow that calls a System Java action — `Administration.ChangeMyPassword` is one example, but it affects every project that uses `System.VerifyPassword`, password handling, or other runtime built-ins.

```bash
$ mxcli describe -p app.mpr microflow Administration.ChangeMyPassword > /tmp/x.mdl
$ mxcli check /tmp/x.mdl --references -p app.mpr
Reference errors:
  statement 1: microflow 'Administration.ChangeMyPassword' has reference errors:
  - java action not found: System.VerifyPassword (referenced by call java action)

✗ 1 reference error(s) found
```

After this PR the same check returns `✓ All references valid`.

## Test plan

- [x] `TestValidateMicroflowReferencesSkipsSystemJavaAction` — `System.VerifyPassword` reference must not error.
- [x] `TestValidateMicroflowReferencesReportsMissingUserJavaAction` — pins that genuine missing user-module Java actions still error (so this skip doesn't mask real typos).
- [x] `go test ./...` passes.
- [x] Manual reproduction on Control Centre's `Administration.ChangeMyPassword`: pre-fix → CE0117 reported by `mxcli check`; post-fix → `✓ All references valid`. Studio Pro's `mx check` was already happy in both cases (`mpr_check_errors=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)