### PR TITLE
fix: prevent catalog crash on duplicate business event channels

### DIFF
--- a/mdl/catalog/builder_contract.go
+++ b/mdl/catalog/builder_contract.go
@@ -138,7 +138,7 @@ func (b *Builder) buildContractMessages() error {
 	}
 
 	stmt, err := b.tx.Prepare(`
-		INSERT INTO contract_messages (Id, ServiceId, ServiceQualifiedName,
+		INSERT OR IGNORE INTO contract_messages (Id, ServiceId, ServiceQualifiedName,
 			ChannelName, OperationType, MessageName, Title, ContentType, PropertyCount,
 			ModuleName, ProjectId, SnapshotId, SnapshotDate, SnapshotSource)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)


### PR DESCRIPTION
## Summary

- `INSERT OR IGNORE INTO contract_messages` to tolerate duplicate rows from Mendix Portal's AsyncAPI documents

## Problem

Mendix-portal's business event module has duplicate channel references across services. This caused a UNIQUE constraint violation that crashed the entire catalog build, making `REFRESH CATALOG FULL` fail — which blocks all cross-reference queries (callers, callees, impact analysis).

<img width="1602" height="708" alt="image" src="https://github.com/user-attachments/assets/0960d6e4-4591-470c-90d4-8827ed2e8d83" />

## Test plan

- [x] `go build ./mdl/catalog/` passes
- [x] `go test ./mdl/catalog/` passes (190 tests)
- [x] Run `REFRESH CATALOG FULL` against a Mendix Portal MPR to confirm no crash
- [x] Verify `SHOW CONTRACT MESSAGES` returns expected rows

<img width="1537" height="1103" alt="image" src="https://github.com/user-attachments/assets/d301c64f-0b81-4f0f-a747-1aec7fe31564" />

<img width="1403" height="243" alt="image" src="https://github.com/user-attachments/assets/2375a27e-1bb5-4a0b-a2e3-76aac2a43d6e" />

