### PR TITLE
fix #590: rewrite OData example Level 9.1 to use TripPin schema actions

### DIFF
--- a/mdl-examples/doctype-tests/10-odata-examples.mdl
+++ b/mdl-examples/doctype-tests/10-odata-examples.mdl
@@ -378,16 +378,15 @@ revoke access on odata service OdTest.CustomerAPI from OdTest.user;
 -- LEVEL 9: EXTERNAL ACTION CALLS IN MICROFLOWS
 -- ############################################################################
 
-/**
- * Level 9.1: Call an external action with parameters and result variable
- */
-create microflow OdTest.ACT_CallExternalAction() returns boolean
-begin
-    $Result = call external action OdTest.SalesforceAPI.GetAccounts(status = 'active', Region = $SelectedRegion);
-    call external action OdTest.SalesforceAPI.NotifyUpdate(AccountId = $AccountId) on error continue;
-    return true;
-end;
-/
+-- Level 9.1: Call an external action — see Level 10.4.1 below.
+--
+-- The microflow is created after Level 10.1 because Studio Pro resolves
+-- `call external action` Name fields against the cached $metadata schema of
+-- the ConsumedODataService. SalesforceAPI's MetadataUrl is a placeholder
+-- that doesn't actually return $metadata, so its cache is empty and any
+-- action call against it would crash Studio Pro's project checker with a
+-- NullReferenceException in CallExternalAction.SchemaAction (see mxcli#590).
+-- TripPin has reachable metadata, so its actions resolve correctly.
 
 /**
  * Level 9.2: Show external actions discovered from microflow usage
@@ -462,14 +461,31 @@ create or modify external entities from TripPinClient."TripPinApiClient"
   into TripPinClient;
 /
 
+/**
+ * Level 10.4.1: Demonstrate `call external action` against TripPin schema
+ * actions. Both ResetDataSource (no parameters) and GetNearestAirport
+ * (parameterised with a return variable) are unbound entries in TripPin's
+ * cached $metadata, so Studio Pro's project checker resolves SchemaAction
+ * correctly. The microflow lives in OdTest to keep `show external actions
+ * in OdTest` (Level 9.2) returning a row, but references the TripPin client.
+ */
+create microflow OdTest.ACT_CallExternalAction() returns boolean
+begin
+    $Airport = call external action TripPinClient."TripPinApiClient".GetNearestAirport(lat = 47.6062, lon = -122.3321);
+    call external action TripPinClient."TripPinApiClient".ResetDataSource() on error continue;
+    return true;
+end;
+/
+
 -- ############################################################################
 -- LEVEL 8.8: DROP (cleanup)
 -- ############################################################################
 
 /**
- * Level 8.8a: Drop objects that reference SalesforceAPI before dropping the client.
- * OdTest.ACT_CallExternalAction calls SalesforceAPI actions; OdTest.RemoteAccount
- * is an external entity backed by SalesforceAPI — both must be removed first.
+ * Level 8.8a: Drop objects that reference OData clients before dropping the
+ * clients themselves. OdTest.ACT_CallExternalAction (created in Level 10.4.1)
+ * calls TripPin actions, and OdTest.RemoteAccount is an external entity
+ * backed by SalesforceAPI — both must be removed first.
  */
 drop microflow OdTest.ACT_CallExternalAction;
 /

--- a/mdl-examples/doctype-tests/10-odata-examples.mdl
+++ b/mdl-examples/doctype-tests/10-odata-examples.mdl
@@ -332,11 +332,19 @@ from odata client OdTest.SalesforceAPI
  * Level 8.6c: Create external entity with AllowCreateChangeLocally flag
  * Enables local creation/changes for the entity, mirroring Studio Pro's
  * "Allow creating and changing locally" checkbox on external entities.
+ *
+ * RemoteName must be repeated here because `create or modify external entity`
+ * currently overwrites omitted properties with empty strings rather than
+ * preserving the existing value. Without `RemoteName: 'Account'`, the BSON
+ * ends up with `"RemoteName": ""`, which Studio Pro's Integration Pane
+ * visualiser cannot render (NRE in ODataRemoteEntitySource.RemoteId,
+ * mxcli#594).
  */
 create or modify external entity OdTest.RemoteAccount
 from odata client OdTest.SalesforceAPI
 (
   EntitySet: 'Accounts',
+  RemoteName: 'Account',
   Countable: Yes,
   Creatable: Yes,
   Deletable: No,


### PR DESCRIPTION
## Summary

Fix two distinct Studio Pro crashes triggered by running `mdl-examples/doctype-tests/10-odata-examples.mdl` against a project.

**Commit 1 — fixes #590** (`CallExternalAction.SchemaAction` NRE in project checker):
The `call external action` demonstration in Level 9.1 referenced fictional actions on `OdTest.SalesforceAPI`. SalesforceAPI's `MetadataUrl` doesn't resolve, so its cached `$metadata` is empty, and Studio Pro NREs trying to resolve the action name against the empty schema. The crash aborts the entire background checker, hiding all other problems.
- Move the microflow definition from Level 9.1 to a new Level 10.4.1, after the TripPin client is created and its `$metadata` cached.
- Use `GetNearestAirport(lat=…, lon=…)` (Function, parameters + return) and `ResetDataSource()` (Action, parameterless + `on error continue`) — both are unbound entries in TripPin's real schema, so Studio Pro resolves them correctly.
- Keep the microflow in `OdTest` so `show external actions in OdTest` (Level 9.2) still returns a row.

**Commit 2 — fixes #594** (`ODataRemoteEntitySource.RemoteId` NRE in Integration Pane):
Level 8.6c was relying on `create or modify external entity` preserving the `RemoteName` previously set by 8.6a/8.6b. The executor actually overwrites omitted properties with empty strings, so the resulting BSON had `RemoteName: ""`. Studio Pro's Integration Pane visualiser then NREs with `ArgumentNullException("EntityTypeName")` because its C# property aliases the BSON `RemoteName` field.
- Re-state `RemoteName: 'Account'` explicitly in Level 8.6c.
- The underlying executor bug (line 818 of `mdl/executor/cmd_odata.go`) is tracked in #594 and will be fixed in its own PR.

## Why two fixes in one PR

Both are one-line example-file changes that unblock the same end-to-end validation (`run example → open in Studio Pro → checker + integration pane work`). The underlying executor and Studio Pro robustness issues are tracked in separate issues (#594, plus #590 itself notes the upstream gap).

## Test plan

- [x] `make build` — passes
- [x] `make test` — passes (nothing in this PR touches Go code)
- [x] `./bin/mxcli check mdl-examples/doctype-tests/10-odata-examples.mdl` → `✓ Syntax OK`
- [ ] **Manual validation in Studio Pro** (requires the user to apply the file to a blank project): open the project, confirm:
  - Background project checker runs without NREing in `CallExternalAction.SchemaAction`
  - Integration Pane renders consumed-service entities without NREing in `ODataRemoteEntitySource.RemoteId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)