### PR TITLE
feat(lint): add --rules / -r flag to isolate rule execution

### DIFF
--- a/cmd/mxcli/cmd_lint.go
+++ b/cmd/mxcli/cmd_lint.go
@@ -77,6 +77,9 @@ Examples:
   mxcli lint -p app.mpr --format json
   mxcli lint -p app.mpr --format sarif > results.sarif
   mxcli lint -p app.mpr --list-rules
+  mxcli lint -p app.mpr -r MPR001
+  mxcli lint -p app.mpr -r MPR001 -r SEC001
+  mxcli lint -p app.mpr -r MPR001,SEC001
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		projectPath, _ := cmd.Flags().GetString("project")

--- a/cmd/mxcli/cmd_lint.go
+++ b/cmd/mxcli/cmd_lint.go
@@ -84,6 +84,7 @@ Examples:
 		useColor, _ := cmd.Flags().GetBool("color")
 		listRules, _ := cmd.Flags().GetBool("list-rules")
 		excludeModules, _ := cmd.Flags().GetStringSlice("exclude")
+		onlyRules, _ := cmd.Flags().GetStringSlice("rules")
 
 		if projectPath == "" {
 			fmt.Fprintln(os.Stderr, "Error: --project (-p) is required")
@@ -153,6 +154,19 @@ Examples:
 		if starlarkRules, err := linter.LoadStarlarkRulesFromDir(lintRulesDir); err == nil {
 			for _, rule := range starlarkRules {
 				lint.AddRule(rule)
+			}
+		}
+
+		// If --rules is specified, disable every rule not in the allowlist.
+		if len(onlyRules) > 0 {
+			allowed := make(map[string]bool, len(onlyRules))
+			for _, id := range onlyRules {
+				allowed[id] = true
+			}
+			for _, rule := range lint.Rules() {
+				if !allowed[rule.ID()] {
+					lint.ConfigureRule(rule.ID(), linter.RuleConfig{Enabled: false})
+				}
 			}
 		}
 

--- a/cmd/mxcli/main.go
+++ b/cmd/mxcli/main.go
@@ -351,6 +351,7 @@ func init() {
 	lintCmd.Flags().BoolP("color", "", false, "Use colored output")
 	lintCmd.Flags().BoolP("list-rules", "l", false, "List available lint rules")
 	lintCmd.Flags().StringSliceP("exclude", "e", nil, "Modules to exclude from linting")
+	lintCmd.Flags().StringSliceP("rules", "r", nil, "Only run these rule IDs (e.g. -r MPR001 -r SEC001)")
 
 	// Report command flags
 	reportCmd.Flags().StringP("format", "f", "markdown", "Output format: markdown, json, html")

--- a/mdl/linter/linter_test.go
+++ b/mdl/linter/linter_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package linter
+
+import (
+	"context"
+	"testing"
+)
+
+// stubRule is a minimal Rule implementation for testing.
+type stubRule struct {
+	id string
+}
+
+func (r *stubRule) ID() string                      { return r.id }
+func (r *stubRule) Name() string                    { return r.id }
+func (r *stubRule) Description() string             { return "" }
+func (r *stubRule) DefaultSeverity() Severity       { return SeverityWarning }
+func (r *stubRule) Category() string                { return "test" }
+func (r *stubRule) Check(_ *LintContext) []Violation {
+	return []Violation{{RuleID: r.id, Severity: SeverityWarning, Message: "hit"}}
+}
+
+func TestRuleFilter_AllowlistRestrictsExecution(t *testing.T) {
+	lint := New(nil)
+	lint.AddRule(&stubRule{"MPR001"})
+	lint.AddRule(&stubRule{"MPR002"})
+	lint.AddRule(&stubRule{"SEC001"})
+
+	// Simulate the --rules allowlist applied in cmd_lint.go.
+	allowed := map[string]bool{"MPR001": true}
+	for _, rule := range lint.Rules() {
+		if !allowed[rule.ID()] {
+			lint.ConfigureRule(rule.ID(), RuleConfig{Enabled: false})
+		}
+	}
+
+	violations, err := lint.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+	if violations[0].RuleID != "MPR001" {
+		t.Errorf("expected MPR001, got %s", violations[0].RuleID)
+	}
+}
+
+func TestRuleFilter_EmptyAllowlistRunsAll(t *testing.T) {
+	lint := New(nil)
+	lint.AddRule(&stubRule{"MPR001"})
+	lint.AddRule(&stubRule{"MPR002"})
+
+	// No --rules flag: no ConfigureRule calls, all rules run.
+	violations, err := lint.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d", len(violations))
+	}
+}
+
+func TestRuleFilter_MultipleRulesAllowed(t *testing.T) {
+	lint := New(nil)
+	lint.AddRule(&stubRule{"MPR001"})
+	lint.AddRule(&stubRule{"MPR002"})
+	lint.AddRule(&stubRule{"SEC001"})
+
+	allowed := map[string]bool{"MPR001": true, "SEC001": true}
+	for _, rule := range lint.Rules() {
+		if !allowed[rule.ID()] {
+			lint.ConfigureRule(rule.ID(), RuleConfig{Enabled: false})
+		}
+	}
+
+	violations, err := lint.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d", len(violations))
+	}
+	ids := map[string]bool{}
+	for _, v := range violations {
+		ids[v.RuleID] = true
+	}
+	if !ids["MPR001"] || !ids["SEC001"] {
+		t.Errorf("expected MPR001 and SEC001, got %v", ids)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `-r` / `--rules` flag to `mxcli lint` that restricts execution to the specified rule IDs
- When the flag is omitted all rules run as before — no behaviour change
- `--list-rules` is unaffected and still shows the full rule catalogue

## Motivation

During lint rule development, running all ~40 rules on every iteration is slow and noisy. This flag lets you pin execution to the rule(s) under development:

```bash
mxcli lint -p app.mpr -r MPR001
mxcli lint -p app.mpr -r MPR001 -r SEC001
mxcli lint -p app.mpr -r MPR001,SEC001   # comma form also works
```

## Implementation

Reuses the existing `Linter.ConfigureRule(id, RuleConfig{Enabled: false})` mechanism — no changes to `linter.go` or any rule files. After all rules (including Starlark) are registered, any rule whose ID is not in the allowlist is disabled before `lint.Run()` is called.

## Test plan

- [ ] `mxcli lint -p app.mpr -r MPR001` — only MPR001 violations appear
- [ ] `mxcli lint -p app.mpr -r MPR001 -r SEC001` — only those two rules run
- [ ] `mxcli lint -p app.mpr` — all rules still run (no regression)
- [ ] `mxcli lint -p app.mpr -r MPR001 --list-rules` — full rule catalogue shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KeDQV2xS3xL16vEZWEDmaw