### PR TITLE
feat(lint): add --modules/-m flag to scope lint to specific modules

### DIFF
--- a/cmd/mxcli/cmd_lint.go
+++ b/cmd/mxcli/cmd_lint.go
@@ -80,6 +80,8 @@ Examples:
   mxcli lint -p app.mpr -r MPR001
   mxcli lint -p app.mpr -r MPR001 -r SEC001
   mxcli lint -p app.mpr -r MPR001,SEC001
+  mxcli lint -p app.mpr -m MyModule
+  mxcli lint -p app.mpr -m MyModule -m AnotherModule
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		projectPath, _ := cmd.Flags().GetString("project")
@@ -88,6 +90,7 @@ Examples:
 		listRules, _ := cmd.Flags().GetBool("list-rules")
 		excludeModules, _ := cmd.Flags().GetStringSlice("exclude")
 		onlyRules, _ := cmd.Flags().GetStringSlice("rules")
+		moduleFilter, _ := cmd.Flags().GetStringSlice("modules")
 
 		if projectPath == "" {
 			fmt.Fprintln(os.Stderr, "Error: --project (-p) is required")
@@ -127,6 +130,9 @@ Examples:
 		// Create lint context
 		ctx := linter.NewLintContext(cat, exec.Backend())
 		ctx.SetExcludedModules(excludeModules)
+		if len(moduleFilter) > 0 {
+			ctx.SetIncludedModules(moduleFilter)
+		}
 
 		// Create linter and register rules
 		lint := linter.New(ctx)

--- a/cmd/mxcli/main.go
+++ b/cmd/mxcli/main.go
@@ -352,6 +352,7 @@ func init() {
 	lintCmd.Flags().BoolP("list-rules", "l", false, "List available lint rules")
 	lintCmd.Flags().StringSliceP("exclude", "e", nil, "Modules to exclude from linting")
 	lintCmd.Flags().StringSliceP("rules", "r", nil, "Only run these rule IDs (e.g. -r MPR001 -r SEC001)")
+	lintCmd.Flags().StringSliceP("modules", "m", nil, "Only lint the specified modules (comma-separated or repeated)")
 
 	// Report command flags
 	reportCmd.Flags().StringP("format", "f", "markdown", "Output format: markdown, json, html")

--- a/mdl/linter/context.go
+++ b/mdl/linter/context.go
@@ -31,6 +31,7 @@ type LintContext struct {
 	catalog  *catalog.Catalog
 	db       catalog.CatalogDB
 	excluded map[string]bool
+	included map[string]bool // when non-empty, only these modules are linted
 	reader   LintReader
 }
 
@@ -67,9 +68,26 @@ func (ctx *LintContext) SetExcludedModules(modules []string) {
 	}
 }
 
-// IsExcluded returns true if the module should be excluded from linting.
+// SetIncludedModules sets an allowlist of modules to lint. When non-empty,
+// only modules in this list are linted (modules not in the list are skipped).
+func (ctx *LintContext) SetIncludedModules(modules []string) {
+	ctx.included = make(map[string]bool)
+	for _, m := range modules {
+		ctx.included[m] = true
+	}
+}
+
+// IsExcluded returns true if the module should be skipped during linting.
+// A module is skipped when it is explicitly excluded, or when an inclusion
+// filter is active and the module is not in it.
 func (ctx *LintContext) IsExcluded(moduleName string) bool {
-	return ctx.excluded[moduleName]
+	if ctx.excluded[moduleName] {
+		return true
+	}
+	if len(ctx.included) > 0 && !ctx.included[moduleName] {
+		return true
+	}
+	return false
 }
 
 // Catalog returns the underlying catalog.
@@ -145,7 +163,7 @@ func (ctx *LintContext) Entities() iter.Seq[Entity] {
 			e.HasEventHandlers = hasEventHandlers == 1
 			e.IsExternal = isExternal == 1
 
-			if ctx.excluded[e.ModuleName] {
+			if ctx.IsExcluded(e.ModuleName) {
 				continue
 			}
 
@@ -444,7 +462,7 @@ func (ctx *LintContext) Microflows() iter.Seq[Microflow] {
 			mf.Description = desc.String
 			mf.ReturnType = retType.String
 
-			if ctx.excluded[mf.ModuleName] {
+			if ctx.IsExcluded(mf.ModuleName) {
 				continue
 			}
 
@@ -499,7 +517,7 @@ func (ctx *LintContext) Pages() iter.Seq[Page] {
 			pg.Description = desc.String
 			pg.WidgetCount = int(widgetCount.Int64)
 
-			if ctx.excluded[pg.ModuleName] {
+			if ctx.IsExcluded(pg.ModuleName) {
 				continue
 			}
 
@@ -548,7 +566,7 @@ func (ctx *LintContext) Enumerations() iter.Seq[Enumeration] {
 			en.Folder = folder.String
 			en.Description = desc.String
 
-			if ctx.excluded[en.ModuleName] {
+			if ctx.IsExcluded(en.ModuleName) {
 				continue
 			}
 
@@ -602,7 +620,7 @@ func (ctx *LintContext) Widgets() iter.Seq[Widget] {
 			w.EntityRef = entityRef.String
 			w.AttributeRef = attrRef.String
 
-			if ctx.excluded[w.ModuleName] {
+			if ctx.IsExcluded(w.ModuleName) {
 				continue
 			}
 
@@ -649,7 +667,7 @@ func (ctx *LintContext) Snippets() iter.Seq[Snippet] {
 			s.Folder = folder.String
 			s.WidgetCount = int(widgetCount.Int64)
 
-			if ctx.excluded[s.ModuleName] {
+			if ctx.IsExcluded(s.ModuleName) {
 				continue
 			}
 
@@ -697,7 +715,7 @@ func (ctx *LintContext) DatabaseConnections() iter.Seq[DatabaseConnection] {
 			}
 			dc.Folder = folder.String
 
-			if ctx.excluded[dc.ModuleName] {
+			if ctx.IsExcluded(dc.ModuleName) {
 				continue
 			}
 

--- a/mdl/linter/context_test.go
+++ b/mdl/linter/context_test.go
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package linter
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/mendixlabs/mxcli/mdl/catalog"
+
+	_ "modernc.org/sqlite"
+)
+
+// setupModuleFilterDB creates an in-memory SQLite database seeded with entities
+// spread across three modules: ModA, ModB, ModC.
+func setupModuleFilterDB(t *testing.T) catalog.CatalogDB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	_, err = db.Exec(`CREATE TABLE modules (Name TEXT PRIMARY KEY, Source TEXT)`)
+	if err != nil {
+		t.Fatalf("create modules table: %v", err)
+	}
+	_, err = db.Exec(`CREATE TABLE entities (
+		Id TEXT, Name TEXT, QualifiedName TEXT, ModuleName TEXT, Folder TEXT,
+		EntityType TEXT, Description TEXT, Generalization TEXT,
+		AttributeCount INTEGER, AccessRuleCount INTEGER, ValidationRuleCount INTEGER,
+		HasEventHandlers INTEGER, IsExternal INTEGER
+	)`)
+	if err != nil {
+		t.Fatalf("create entities table: %v", err)
+	}
+	_, err = db.Exec(`CREATE TABLE microflows (
+		Id TEXT, Name TEXT, QualifiedName TEXT, ModuleName TEXT, Folder TEXT,
+		MicroflowType TEXT, Description TEXT, ReturnType TEXT,
+		ParameterCount INTEGER, ActivityCount INTEGER, Complexity INTEGER
+	)`)
+	if err != nil {
+		t.Fatalf("create microflows table: %v", err)
+	}
+
+	modules := []string{"ModA", "ModB", "ModC"}
+	for _, mod := range modules {
+		if _, err := db.Exec(`INSERT INTO modules VALUES (?, '')`, mod); err != nil {
+			t.Fatalf("insert module %s: %v", mod, err)
+		}
+		if _, err := db.Exec(`INSERT INTO entities VALUES (?, ?, ?, ?, '', 'PERSISTENT', '', '', 0, 0, 0, 0, 0)`,
+			mod+"_e", mod+"_Entity", mod+".Entity", mod); err != nil {
+			t.Fatalf("insert entity for %s: %v", mod, err)
+		}
+		if _, err := db.Exec(`INSERT INTO microflows VALUES (?, ?, ?, ?, '', 'Microflow', '', '', 0, 0, 0)`,
+			mod+"_mf", mod+"_Flow", mod+".Flow", mod); err != nil {
+			t.Fatalf("insert microflow for %s: %v", mod, err)
+		}
+	}
+
+	return catalog.WrapSqlDB(db)
+}
+
+// collectEntityModules iterates Entities() and returns the set of module names seen.
+func collectEntityModules(ctx *LintContext) map[string]bool {
+	seen := map[string]bool{}
+	for e := range ctx.Entities() {
+		seen[e.ModuleName] = true
+	}
+	return seen
+}
+
+// collectMicroflowModules iterates Microflows() and returns the set of module names seen.
+func collectMicroflowModules(ctx *LintContext) map[string]bool {
+	seen := map[string]bool{}
+	for mf := range ctx.Microflows() {
+		seen[mf.ModuleName] = true
+	}
+	return seen
+}
+
+// --- IsExcluded unit tests ---
+
+func TestIsExcluded_NoFilters(t *testing.T) {
+	ctx := NewLintContextFromDB(setupModuleFilterDB(t))
+	for _, mod := range []string{"ModA", "ModB", "ModC"} {
+		if ctx.IsExcluded(mod) {
+			t.Errorf("IsExcluded(%q) = true with no filters, want false", mod)
+		}
+	}
+}
+
+func TestIsExcluded_ExcludeOnly(t *testing.T) {
+	ctx := NewLintContextFromDB(setupModuleFilterDB(t))
+	ctx.SetExcludedModules([]string{"ModB"})
+
+	if ctx.IsExcluded("ModA") {
+		t.Error("ModA should not be excluded")
+	}
+	if !ctx.IsExcluded("ModB") {
+		t.Error("ModB should be excluded")
+	}
+	if ctx.IsExcluded("ModC") {
+		t.Error("ModC should not be excluded")
+	}
+}
+
+func TestIsExcluded_IncludeOnly(t *testing.T) {
+	ctx := NewLintContextFromDB(setupModuleFilterDB(t))
+	ctx.SetIncludedModules([]string{"ModA"})
+
+	if ctx.IsExcluded("ModA") {
+		t.Error("ModA is in the inclusion list and should not be excluded")
+	}
+	if !ctx.IsExcluded("ModB") {
+		t.Error("ModB is not in the inclusion list and should be excluded")
+	}
+	if !ctx.IsExcluded("ModC") {
+		t.Error("ModC is not in the inclusion list and should be excluded")
+	}
+}
+
+func TestIsExcluded_IncludeAndExcludeCombined(t *testing.T) {
+	// Include ModA and ModB, but explicitly exclude ModB — ModB should be excluded.
+	ctx := NewLintContextFromDB(setupModuleFilterDB(t))
+	ctx.SetIncludedModules([]string{"ModA", "ModB"})
+	ctx.SetExcludedModules([]string{"ModB"})
+
+	if ctx.IsExcluded("ModA") {
+		t.Error("ModA should pass: it is included and not excluded")
+	}
+	if !ctx.IsExcluded("ModB") {
+		t.Error("ModB should be excluded: explicit exclude wins over include")
+	}
+	if !ctx.IsExcluded("ModC") {
+		t.Error("ModC should be excluded: not in inclusion list")
+	}
+}
+
+func TestIsExcluded_EmptyInclusionListNoOp(t *testing.T) {
+	// SetIncludedModules with an empty slice should behave as if no filter was set.
+	ctx := NewLintContextFromDB(setupModuleFilterDB(t))
+	ctx.SetIncludedModules([]string{})
+
+	for _, mod := range []string{"ModA", "ModB", "ModC"} {
+		if ctx.IsExcluded(mod) {
+			t.Errorf("IsExcluded(%q) = true after empty SetIncludedModules, want false", mod)
+		}
+	}
+}
+
+func TestIsExcluded_MultipleIncludedModules(t *testing.T) {
+	ctx := NewLintContextFromDB(setupModuleFilterDB(t))
+	ctx.SetIncludedModules([]string{"ModA", "ModC"})
+
+	if ctx.IsExcluded("ModA") {
+		t.Error("ModA should not be excluded")
+	}
+	if !ctx.IsExcluded("ModB") {
+		t.Error("ModB should be excluded: not in inclusion list")
+	}
+	if ctx.IsExcluded("ModC") {
+		t.Error("ModC should not be excluded")
+	}
+}
+
+// --- Iterator integration tests ---
+
+func TestEntitiesIterator_InclusionFilter(t *testing.T) {
+	ctx := NewLintContextFromDB(setupModuleFilterDB(t))
+	ctx.SetIncludedModules([]string{"ModA"})
+
+	seen := collectEntityModules(ctx)
+	if !seen["ModA"] {
+		t.Error("expected ModA entities to be yielded")
+	}
+	if seen["ModB"] || seen["ModC"] {
+		t.Error("expected ModB and ModC entities to be filtered out")
+	}
+}
+
+func TestEntitiesIterator_ExclusionFilter(t *testing.T) {
+	ctx := NewLintContextFromDB(setupModuleFilterDB(t))
+	ctx.SetExcludedModules([]string{"ModB"})
+
+	seen := collectEntityModules(ctx)
+	if !seen["ModA"] || !seen["ModC"] {
+		t.Error("expected ModA and ModC entities to be yielded")
+	}
+	if seen["ModB"] {
+		t.Error("expected ModB entities to be filtered out")
+	}
+}
+
+func TestEntitiesIterator_NoFilters(t *testing.T) {
+	ctx := NewLintContextFromDB(setupModuleFilterDB(t))
+
+	seen := collectEntityModules(ctx)
+	for _, mod := range []string{"ModA", "ModB", "ModC"} {
+		if !seen[mod] {
+			t.Errorf("expected %s entities with no filters", mod)
+		}
+	}
+}
+
+func TestMicroflowsIterator_InclusionFilter(t *testing.T) {
+	ctx := NewLintContextFromDB(setupModuleFilterDB(t))
+	ctx.SetIncludedModules([]string{"ModB"})
+
+	seen := collectMicroflowModules(ctx)
+	if !seen["ModB"] {
+		t.Error("expected ModB microflows to be yielded")
+	}
+	if seen["ModA"] || seen["ModC"] {
+		t.Error("expected ModA and ModC microflows to be filtered out")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `--modules / -m` flag to `mxcli lint` to filter linting to a specific set of modules (inclusion/allowlist), complementing the existing `--exclude` flag
- Useful during rule development to iterate quickly without noise from unrelated modules
- Accepts repeated flags (`-m A -m B`) or comma-separated values (`-m A,B`)

## Changes

**`mdl/linter/context.go`**
- Added `included map[string]bool` field to `LintContext`
- Added `SetIncludedModules([]string)` method
- Extended `IsExcluded()` to return `true` when an inclusion filter is active and the module is not in it
- Updated all 7 catalog iterators (`Entities`, `Microflows`, `Pages`, `Enumerations`, `Widgets`, `Snippets`, `DatabaseConnections`) to call `ctx.IsExcluded()` instead of reading `ctx.excluded` map directly — ensures the new filter is respected automatically everywhere

**`cmd/mxcli/main.go`**
- Registered `--modules / -m` (`StringSliceP`) flag for `lintCmd`

**`cmd/mxcli/cmd_lint.go`**
- Reads the new flag and calls `ctx.SetIncludedModules()` when set
- Added usage examples to the command `Long` description

## Usage

```bash
# Scope to a single module
mxcli lint -p app.mpr -m MyModule

# Scope to multiple modules
mxcli lint -p app.mpr -m MyModule -m AnotherModule
mxcli lint -p app.mpr -m MyModule,AnotherModule

# Combined with --exclude (exclude takes priority within the included set)
mxcli lint -p app.mpr -m MyModule --exclude SubModule
```

## Test plan

- [x] `go build ./...` — clean build
- [x] `go test ./mdl/linter/...` — all linter tests pass
- [ ] Manual: `mxcli lint -p app.mpr -m <module>` — violations only reference the specified module
- [ ] Manual: `mxcli lint --list-rules` — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZV9A7j6FFSjPnYJQjNJ5v