### PR TITLE
feat(lint): expose constants() query function to Starlark lint rules

### DIFF
--- a/.claude/skills/mendix/write-lint-rules.md
+++ b/.claude/skills/mendix/write-lint-rules.md
@@ -27,6 +27,7 @@ def check():
 | `microflows()` | list of microflow | All non-system microflows |
 | `pages()` | list of page | All non-system pages |
 | `enumerations()` | list of enumeration | All non-system enumerations |
+| `constants()` | list of constant | All non-system constants |
 | `widgets()` | list of widget | All non-system widgets |
 | `snippets()` | list of snippet | All non-system snippets |
 | `attributes_for(entity_qualified_name)` | list of attribute | Attributes for a specific entity |
@@ -145,6 +146,18 @@ def check():
 | `folder` | string | `"enumerations"` — folder path within module |
 | `description` | string | Documentation text |
 | `value_count` | int | Number of enum values |
+
+### constant
+| Property | Type | Example |
+|----------|------|---------|
+| `id` | string | Document UUID |
+| `name` | string | `"AppBaseUrl"` |
+| `qualified_name` | string | `"MyModule.AppBaseUrl"` |
+| `module_name` | string | `"MyModule"` |
+| `folder` | string | `"constants"` — folder path within module |
+| `description` | string | Documentation text |
+| `default_value` | string | `"https://example.com"` |
+| `exposed_to_client` | bool | `true` if constant is exposed to client |
 
 ### widget
 | Property | Type | Example |

--- a/mdl/linter/context.go
+++ b/mdl/linter/context.go
@@ -559,6 +559,59 @@ func (ctx *LintContext) Enumerations() iter.Seq[Enumeration] {
 	}
 }
 
+// LintConstant represents a constant from the catalog.
+type LintConstant struct {
+	ID              string
+	Name            string
+	QualifiedName   string
+	ModuleName      string
+	Folder          string
+	Description     string
+	DefaultValue    string
+	ExposedToClient bool
+}
+
+// Constants returns an iterator over all constants (excluding system modules).
+func (ctx *LintContext) Constants() iter.Seq[LintConstant] {
+	return func(yield func(LintConstant) bool) {
+		rows, err := ctx.db.Query(`
+			SELECT c.Id, c.Name, c.QualifiedName, c.ModuleName, c.Folder,
+			       c.Description, c.DefaultValue, c.ExposedToClient
+			FROM constants c
+			LEFT JOIN modules m ON c.ModuleName = m.Name
+			WHERE COALESCE(m.Source, '') = ''
+			ORDER BY c.ModuleName, c.Name
+		`)
+		if err != nil {
+			return
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var c LintConstant
+			var folder, desc, defaultVal sql.NullString
+			var exposedToClient int
+			err := rows.Scan(&c.ID, &c.Name, &c.QualifiedName, &c.ModuleName,
+				&folder, &desc, &defaultVal, &exposedToClient)
+			if err != nil {
+				continue
+			}
+			c.Folder = folder.String
+			c.Description = desc.String
+			c.DefaultValue = defaultVal.String
+			c.ExposedToClient = exposedToClient == 1
+
+			if ctx.excluded[c.ModuleName] {
+				continue
+			}
+
+			if !yield(c) {
+				return
+			}
+		}
+	}
+}
+
 // Widget represents a widget from the catalog.
 type Widget struct {
 	ID                     string

--- a/mdl/linter/starlark.go
+++ b/mdl/linter/starlark.go
@@ -232,6 +232,7 @@ func (r *StarlarkRule) buildPredeclared() starlark.StringDict {
 		"microflows":     starlark.NewBuiltin("microflows", r.builtinMicroflows),
 		"pages":          starlark.NewBuiltin("pages", r.builtinPages),
 		"enumerations":   starlark.NewBuiltin("enumerations", r.builtinEnumerations),
+		"constants":      starlark.NewBuiltin("constants", r.builtinConstants),
 		"widgets":        starlark.NewBuiltin("widgets", r.builtinWidgets),
 		"refs_to":        starlark.NewBuiltin("refs_to", r.builtinRefsTo),
 		"refs_from":      starlark.NewBuiltin("refs_from", r.builtinRefsFrom),
@@ -325,6 +326,20 @@ func (r *StarlarkRule) builtinEnumerations(_ *starlark.Thread, _ *starlark.Built
 	}
 
 	return starlark.NewList(enums), nil
+}
+
+// builtinConstants returns an iterator over constants.
+func (r *StarlarkRule) builtinConstants(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if r.ctx == nil {
+		return starlark.NewList(nil), nil
+	}
+
+	var constants []starlark.Value
+	for c := range r.ctx.Constants() {
+		constants = append(constants, constantToStarlark(c))
+	}
+
+	return starlark.NewList(constants), nil
 }
 
 // builtinWidgets returns an iterator over widgets.
@@ -612,6 +627,20 @@ func enumerationToStarlark(e Enumeration) starlark.Value {
 		"folder":         starlark.String(e.Folder),
 		"description":    starlark.String(e.Description),
 		"value_count":    starlark.MakeInt(e.ValueCount),
+	})
+}
+
+// constantToStarlark converts a LintConstant to a Starlark struct.
+func constantToStarlark(c LintConstant) starlark.Value {
+	return starlarkstruct.FromStringDict(starlark.String("constant"), starlark.StringDict{
+		"id":                starlark.String(c.ID),
+		"name":              starlark.String(c.Name),
+		"qualified_name":    starlark.String(c.QualifiedName),
+		"module_name":       starlark.String(c.ModuleName),
+		"folder":            starlark.String(c.Folder),
+		"description":       starlark.String(c.Description),
+		"default_value":     starlark.String(c.DefaultValue),
+		"exposed_to_client": starlark.Bool(c.ExposedToClient),
 	})
 }
 


### PR DESCRIPTION
## Summary

- Adds `constants()` as a new query function available in Starlark custom lint rules
- Exposes 8 properties per constant: `id`, `name`, `qualified_name`, `module_name`, `folder`, `description`, `default_value`, `exposed_to_client`
- Updates the `write-lint-rules.md` skill with the function signature and full property table

## Implementation

The catalog already populated `constants_data` / `constants` view from the MPR file. This PR wires that data through two layers that were missing:

1. **`mdl/linter/context.go`** — `LintConstant` struct + `Constants() iter.Seq[LintConstant]` method, querying the `constants` catalog view and respecting excluded-module filtering
2. **`mdl/linter/starlark.go`** — `builtinConstants()` method, `constantToStarlark()` converter, and registration in `buildPredeclared()`
3. **`.claude/skills/mendix/write-lint-rules.md`** — documents `constants()` in the Available Query Functions table and adds a `### constant` object properties section

## Example rule

```python
def check():
    return [
        violation(
            message = "Exposed constant has no default value: " + c.qualified_name,
            location = c.module_name,
        )
        for c in constants()
        if c.exposed_to_client and c.default_value == ""
    ]

RULES = [rule(id = "CONV001", name = "Exposed constants must have a default value", fn = check)]
```

## Test plan

- [x] `go build ./mdl/linter/...` passes
- [x] `go test ./mdl/linter/...` passes
- [ ] Manual: run `mxcli lint -p app.mpr --rules my_rules/` with a rule that calls `constants()` and confirm results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nq5xEDmnhVMd2HKVt1hiN3