### PR TITLE
feat(lint): expose scheduled_events() query function in Starlark rules

### DIFF
--- a/.claude/skills/mendix/write-lint-rules.md
+++ b/.claude/skills/mendix/write-lint-rules.md
@@ -30,6 +30,7 @@ def check():
 | `constants()` | list of constant | All non-system constants |
 | `widgets()` | list of widget | All non-system widgets |
 | `snippets()` | list of snippet | All non-system snippets |
+| `scheduled_events()` | list of scheduled_event | All non-system scheduled events (requires MPR reader) |
 | `attributes_for(entity_qualified_name)` | list of attribute | Attributes for a specific entity |
 | `activities_for(microflow_qualified_name)` | list of activity | Activities for a microflow (requires FULL catalog) |
 | `permissions()` | list of permission | All permissions across all element types |
@@ -181,6 +182,16 @@ def check():
 | `module_name` | string | `"Sales"` |
 | `folder` | string | `"snippets"` — folder path within module |
 | `widget_count` | int | Number of widgets |
+
+### scheduled_event
+| Property | Type | Example |
+|----------|------|---------|
+| `name` | string | `"SE_NightlyCleanup"` |
+| `qualified_name` | string | `"MyModule.SE_NightlyCleanup"` |
+| `module_name` | string | `"MyModule"` |
+| `microflow_name` | string | `"MyModule.MF_NightlyCleanup"` — resolved from catalog; raw UUID when catalog not built |
+| `interval_seconds` | int | `86400` — `0` for unrecognised interval type |
+| `enabled` | bool | `True` if the event is active |
 
 ### attribute
 | Property | Type | Example |

--- a/mdl/linter/context.go
+++ b/mdl/linter/context.go
@@ -24,6 +24,7 @@ type LintReader interface {
 	ListModules() ([]*model.Module, error)
 	ListFolders() ([]*types.FolderInfo, error)
 	GetRawUnit(id model.ID) (map[string]any, error)
+	ListScheduledEvents() ([]*model.ScheduledEvent, error)
 }
 
 // LintContext wraps a catalog and provides rule-friendly APIs.
@@ -725,6 +726,81 @@ func (ctx *LintContext) Snippets() iter.Seq[Snippet] {
 			}
 
 			if !yield(s) {
+				return
+			}
+		}
+	}
+}
+
+// ScheduledEvent represents a scheduled event document.
+type ScheduledEvent struct {
+	Name            string
+	QualifiedName   string
+	ModuleName      string
+	MicroflowName   string // qualified name of the microflow to execute
+	IntervalSeconds int
+	Enabled         bool
+}
+
+// intervalToSeconds converts a Mendix interval value and type to seconds.
+func intervalToSeconds(interval int, intervalType string) int {
+	multipliers := map[string]int{
+		"Second": 1,
+		"Minute": 60,
+		"Hour":   3600,
+		"Day":    86400,
+		"Week":   604800,
+		"Month":  2592000,
+		"Year":   31536000,
+	}
+	if mult, ok := multipliers[intervalType]; ok {
+		return interval * mult
+	}
+	return 0
+}
+
+// ScheduledEvents returns an iterator over all scheduled events (excluding system modules).
+// Returns an empty iterator if no reader is available.
+func (ctx *LintContext) ScheduledEvents() iter.Seq[ScheduledEvent] {
+	return func(yield func(ScheduledEvent) bool) {
+		if ctx.reader == nil {
+			return
+		}
+
+		// Build module ID → name map from catalog.
+		moduleNames := map[model.ID]string{}
+		if ctx.db != nil {
+			rows, err := ctx.db.Query(`SELECT Id, Name FROM modules`)
+			if err == nil {
+				defer rows.Close()
+				for rows.Next() {
+					var id, name string
+					if rows.Scan(&id, &name) == nil {
+						moduleNames[model.ID(id)] = name
+					}
+				}
+			}
+		}
+
+		events, err := ctx.reader.ListScheduledEvents()
+		if err != nil {
+			return
+		}
+
+		for _, e := range events {
+			moduleName := moduleNames[e.ContainerID]
+			if ctx.IsExcluded(moduleName) {
+				continue
+			}
+			se := ScheduledEvent{
+				Name:            e.Name,
+				QualifiedName:   moduleName + "." + e.Name,
+				ModuleName:      moduleName,
+				MicroflowName:   string(e.MicroflowID),
+				IntervalSeconds: intervalToSeconds(e.Interval, e.IntervalType),
+				Enabled:         e.Enabled,
+			}
+			if !yield(se) {
 				return
 			}
 		}

--- a/mdl/linter/context.go
+++ b/mdl/linter/context.go
@@ -743,6 +743,7 @@ type ScheduledEvent struct {
 }
 
 // intervalToSeconds converts a Mendix interval value and type to seconds.
+// Returns 0 for unrecognised interval types (treated as "not convertible").
 func intervalToSeconds(interval int, intervalType string) int {
 	multipliers := map[string]int{
 		"Second": 1,
@@ -769,14 +770,25 @@ func (ctx *LintContext) ScheduledEvents() iter.Seq[ScheduledEvent] {
 
 		// Build module ID → name map from catalog.
 		moduleNames := map[model.ID]string{}
+		// Build microflow UUID → qualified name map from catalog.
+		// Falls back to the raw UUID when the catalog has not been built yet.
+		microflowNames := map[string]string{}
 		if ctx.db != nil {
-			rows, err := ctx.db.Query(`SELECT Id, Name FROM modules`)
-			if err == nil {
+			if rows, err := ctx.db.Query(`SELECT Id, Name FROM modules`); err == nil {
 				defer rows.Close()
 				for rows.Next() {
 					var id, name string
 					if rows.Scan(&id, &name) == nil {
 						moduleNames[model.ID(id)] = name
+					}
+				}
+			}
+			if rows, err := ctx.db.Query(`SELECT Id, QualifiedName FROM microflows`); err == nil {
+				defer rows.Close()
+				for rows.Next() {
+					var id, qname string
+					if rows.Scan(&id, &qname) == nil {
+						microflowNames[id] = qname
 					}
 				}
 			}
@@ -792,11 +804,15 @@ func (ctx *LintContext) ScheduledEvents() iter.Seq[ScheduledEvent] {
 			if ctx.IsExcluded(moduleName) {
 				continue
 			}
+			mfName := microflowNames[string(e.MicroflowID)]
+			if mfName == "" {
+				mfName = string(e.MicroflowID)
+			}
 			se := ScheduledEvent{
 				Name:            e.Name,
 				QualifiedName:   moduleName + "." + e.Name,
 				ModuleName:      moduleName,
-				MicroflowName:   string(e.MicroflowID),
+				MicroflowName:   mfName,
 				IntervalSeconds: intervalToSeconds(e.Interval, e.IntervalType),
 				Enabled:         e.Enabled,
 			}

--- a/mdl/linter/starlark.go
+++ b/mdl/linter/starlark.go
@@ -228,15 +228,16 @@ func LoadStarlarkRule(path string) (*StarlarkRule, error) {
 func (r *StarlarkRule) buildPredeclared() starlark.StringDict {
 	return starlark.StringDict{
 		// Query functions
-		"entities":       starlark.NewBuiltin("entities", r.builtinEntities),
-		"microflows":     starlark.NewBuiltin("microflows", r.builtinMicroflows),
-		"pages":          starlark.NewBuiltin("pages", r.builtinPages),
-		"enumerations":   starlark.NewBuiltin("enumerations", r.builtinEnumerations),
-		"constants":      starlark.NewBuiltin("constants", r.builtinConstants),
-		"widgets":        starlark.NewBuiltin("widgets", r.builtinWidgets),
-		"refs_to":        starlark.NewBuiltin("refs_to", r.builtinRefsTo),
-		"refs_from":      starlark.NewBuiltin("refs_from", r.builtinRefsFrom),
-		"attributes_for": starlark.NewBuiltin("attributes_for", r.builtinAttributesFor),
+		"entities":         starlark.NewBuiltin("entities", r.builtinEntities),
+		"microflows":       starlark.NewBuiltin("microflows", r.builtinMicroflows),
+		"pages":            starlark.NewBuiltin("pages", r.builtinPages),
+		"enumerations":     starlark.NewBuiltin("enumerations", r.builtinEnumerations),
+		"constants":        starlark.NewBuiltin("constants", r.builtinConstants),
+		"widgets":          starlark.NewBuiltin("widgets", r.builtinWidgets),
+		"refs_to":          starlark.NewBuiltin("refs_to", r.builtinRefsTo),
+		"refs_from":        starlark.NewBuiltin("refs_from", r.builtinRefsFrom),
+		"attributes_for":   starlark.NewBuiltin("attributes_for", r.builtinAttributesFor),
+		"scheduled_events": starlark.NewBuiltin("scheduled_events", r.builtinScheduledEvents),
 
 		// Graph-analysis facts (populated by `refresh catalog communities`).
 		"community_of":         starlark.NewBuiltin("community_of", r.builtinCommunityOf),
@@ -459,6 +460,20 @@ func (r *StarlarkRule) builtinDatabaseConnections(_ *starlark.Thread, _ *starlar
 	}
 
 	return starlark.NewList(connections), nil
+}
+
+// builtinScheduledEvents returns all scheduled events.
+func (r *StarlarkRule) builtinScheduledEvents(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	if r.ctx == nil {
+		return starlark.NewList(nil), nil
+	}
+
+	var result []starlark.Value
+	for se := range r.ctx.ScheduledEvents() {
+		result = append(result, scheduledEventToStarlark(se))
+	}
+
+	return starlark.NewList(result), nil
 }
 
 // builtinActivitiesFor returns the activities for a given microflow.
@@ -786,6 +801,17 @@ func databaseConnectionToStarlark(dc DatabaseConnection) starlark.Value {
 		"folder":         starlark.String(dc.Folder),
 		"database_type":  starlark.String(dc.DatabaseType),
 		"query_count":    starlark.MakeInt(dc.QueryCount),
+	})
+}
+
+func scheduledEventToStarlark(se ScheduledEvent) starlark.Value {
+	return starlarkstruct.FromStringDict(starlark.String("scheduled_event"), starlark.StringDict{
+		"name":             starlark.String(se.Name),
+		"qualified_name":   starlark.String(se.QualifiedName),
+		"module_name":      starlark.String(se.ModuleName),
+		"microflow_name":   starlark.String(se.MicroflowName),
+		"interval_seconds": starlark.MakeInt(se.IntervalSeconds),
+		"enabled":          starlark.Bool(se.Enabled),
 	})
 }
 

--- a/mdl/linter/starlark_scheduledevents_test.go
+++ b/mdl/linter/starlark_scheduledevents_test.go
@@ -203,6 +203,47 @@ func TestScheduledEvents_ExcludedModules(t *testing.T) {
 	}
 }
 
+func TestScheduledEvents_IncludedModules(t *testing.T) {
+	modA := model.ID("mod-a")
+	modB := model.ID("mod-b")
+
+	reader := &minimalReader{
+		listScheduledEvents: func() ([]*model.ScheduledEvent, error) {
+			return []*model.ScheduledEvent{
+				{ContainerID: modA, Name: "SE_A", Interval: 1, IntervalType: "Hour", Enabled: true},
+				{ContainerID: modB, Name: "SE_B", Interval: 1, IntervalType: "Hour", Enabled: true},
+			}, nil
+		},
+	}
+
+	cat, err := catalog.NewFromFile(filepath.Join(t.TempDir(), "cat.db"))
+	if err != nil {
+		t.Fatalf("NewFromFile: %v", err)
+	}
+	defer cat.Close()
+	db := cat.CatalogDB()
+
+	for _, row := range []struct{ id, name string }{{string(modA), "ModA"}, {string(modB), "ModB"}} {
+		if _, err := db.Exec(
+			`INSERT INTO modules_data (Id, Name, ProjectId, SnapshotId) VALUES (?,?,?,?)`,
+			row.id, row.name, "default", "s1",
+		); err != nil {
+			t.Fatalf("insert module %s: %v", row.name, err)
+		}
+	}
+
+	ctx := linter.NewLintContext(cat, reader)
+	ctx.SetIncludedModules([]string{"ModA"}) // only ModA is in scope
+
+	var names []string
+	for se := range ctx.ScheduledEvents() {
+		names = append(names, se.ModuleName)
+	}
+	if len(names) != 1 || names[0] != "ModA" {
+		t.Errorf("expected [ModA], got %v", names)
+	}
+}
+
 func TestScheduledEvents_NilReader(t *testing.T) {
 	cat, err := catalog.NewFromFile(filepath.Join(t.TempDir(), "cat.db"))
 	if err != nil {

--- a/mdl/linter/starlark_scheduledevents_test.go
+++ b/mdl/linter/starlark_scheduledevents_test.go
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package linter_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mendixlabs/mxcli/mdl/catalog"
+	"github.com/mendixlabs/mxcli/mdl/linter"
+	"github.com/mendixlabs/mxcli/mdl/types"
+	"github.com/mendixlabs/mxcli/model"
+	"github.com/mendixlabs/mxcli/sdk/microflows"
+	"github.com/mendixlabs/mxcli/sdk/pages"
+	"github.com/mendixlabs/mxcli/sdk/security"
+)
+
+// minimalReader is a test double for LintReader that returns empty/nil for
+// everything except ListScheduledEvents, which is configurable via a func field.
+type minimalReader struct {
+	listScheduledEvents func() ([]*model.ScheduledEvent, error)
+}
+
+func (m *minimalReader) GetMicroflow(_ model.ID) (*microflows.Microflow, error) {
+	return nil, nil
+}
+func (m *minimalReader) GetProjectSecurity() (*security.ProjectSecurity, error) { return nil, nil }
+func (m *minimalReader) GetNavigation() (*types.NavigationDocument, error)      { return nil, nil }
+func (m *minimalReader) ListPages() ([]*pages.Page, error)                      { return nil, nil }
+func (m *minimalReader) ListModules() ([]*model.Module, error)                  { return nil, nil }
+func (m *minimalReader) ListFolders() ([]*types.FolderInfo, error)              { return nil, nil }
+func (m *minimalReader) GetRawUnit(_ model.ID) (map[string]any, error)          { return nil, nil }
+func (m *minimalReader) ListScheduledEvents() ([]*model.ScheduledEvent, error) {
+	if m.listScheduledEvents != nil {
+		return m.listScheduledEvents()
+	}
+	return nil, nil
+}
+
+// TestIntervalToSeconds is a white-box test; we call it via the exported
+// ScheduledEvents iterator rather than calling the unexported helper directly.
+// The expected IntervalSeconds values verify all multipliers and the unknown-type fallback.
+func TestIntervalToSeconds(t *testing.T) {
+	tests := []struct {
+		interval     int
+		intervalType string
+		want         int
+	}{
+		{1, "Second", 1},
+		{2, "Minute", 120},
+		{3, "Hour", 10800},
+		{1, "Day", 86400},
+		{1, "Week", 604800},
+		{1, "Month", 2592000},
+		{1, "Year", 31536000},
+		{5, "Unknown", 0}, // unrecognised type → 0
+		{5, "", 0},        // empty type → 0
+	}
+
+	containerID := model.ID("mod-1")
+	for _, tt := range tests {
+		reader := &minimalReader{
+			listScheduledEvents: func() ([]*model.ScheduledEvent, error) {
+				return []*model.ScheduledEvent{{
+					ContainerID:  containerID,
+					Name:         "SE",
+					Interval:     tt.interval,
+					IntervalType: tt.intervalType,
+					Enabled:      true,
+				}}, nil
+			},
+		}
+
+		cat, err := catalog.NewFromFile(filepath.Join(t.TempDir(), "cat.db"))
+		if err != nil {
+			t.Fatalf("NewFromFile: %v", err)
+		}
+		db := cat.CatalogDB()
+		if _, err := db.Exec(
+			`INSERT INTO modules_data (Id, Name, ProjectId, SnapshotId) VALUES (?,?,?,?)`,
+			string(containerID), "MyModule", "default", "s1",
+		); err != nil {
+			t.Fatalf("insert module: %v", err)
+		}
+		cat.Close()
+
+		ctx := linter.NewLintContext(cat, reader)
+		var got int
+		for se := range ctx.ScheduledEvents() {
+			got = se.IntervalSeconds
+		}
+		if got != tt.want {
+			t.Errorf("interval=%d type=%q: IntervalSeconds=%d, want %d", tt.interval, tt.intervalType, got, tt.want)
+		}
+	}
+}
+
+func TestScheduledEvents_MicroflowNameResolution(t *testing.T) {
+	containerID := model.ID("mod-uuid")
+	mfID := model.ID("mf-uuid-1234")
+
+	reader := &minimalReader{
+		listScheduledEvents: func() ([]*model.ScheduledEvent, error) {
+			return []*model.ScheduledEvent{
+				{
+					ContainerID:  containerID,
+					Name:         "SEWithCatalog",
+					MicroflowID:  mfID,
+					Interval:     1,
+					IntervalType: "Hour",
+					Enabled:      true,
+				},
+				{
+					ContainerID:  containerID,
+					Name:         "SEWithoutCatalog",
+					MicroflowID:  model.ID("unknown-uuid"),
+					Interval:     1,
+					IntervalType: "Hour",
+					Enabled:      false,
+				},
+			}, nil
+		},
+	}
+
+	cat, err := catalog.NewFromFile(filepath.Join(t.TempDir(), "cat.db"))
+	if err != nil {
+		t.Fatalf("NewFromFile: %v", err)
+	}
+	defer cat.Close()
+	db := cat.CatalogDB()
+
+	if _, err := db.Exec(
+		`INSERT INTO modules_data (Id, Name, ProjectId, SnapshotId) VALUES (?,?,?,?)`,
+		string(containerID), "MyModule", "default", "s1",
+	); err != nil {
+		t.Fatalf("insert module: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO microflows_data (Id, Name, QualifiedName, ModuleName, MicroflowType, ProjectId, SnapshotId)
+		 VALUES (?,?,?,?,?,?,?)`,
+		string(mfID), "ACT_DoSomething", "MyModule.ACT_DoSomething", "MyModule", "Microflow", "default", "s1",
+	); err != nil {
+		t.Fatalf("insert microflow: %v", err)
+	}
+
+	ctx := linter.NewLintContext(cat, reader)
+	events := make(map[string]linter.ScheduledEvent)
+	for se := range ctx.ScheduledEvents() {
+		events[se.Name] = se
+	}
+
+	// When the microflow ID is in the catalog, MicroflowName must be the qualified name.
+	if got := events["SEWithCatalog"].MicroflowName; got != "MyModule.ACT_DoSomething" {
+		t.Errorf("SEWithCatalog.MicroflowName = %q, want %q", got, "MyModule.ACT_DoSomething")
+	}
+
+	// When the microflow ID is not in the catalog, fall back to the raw UUID.
+	if got := events["SEWithoutCatalog"].MicroflowName; got != "unknown-uuid" {
+		t.Errorf("SEWithoutCatalog.MicroflowName = %q, want raw UUID %q", got, "unknown-uuid")
+	}
+}
+
+func TestScheduledEvents_ExcludedModules(t *testing.T) {
+	containerID := model.ID("mod-excl")
+
+	reader := &minimalReader{
+		listScheduledEvents: func() ([]*model.ScheduledEvent, error) {
+			return []*model.ScheduledEvent{{
+				ContainerID:  containerID,
+				Name:         "ExcludedSE",
+				Interval:     1,
+				IntervalType: "Day",
+				Enabled:      true,
+			}}, nil
+		},
+	}
+
+	cat, err := catalog.NewFromFile(filepath.Join(t.TempDir(), "cat.db"))
+	if err != nil {
+		t.Fatalf("NewFromFile: %v", err)
+	}
+	defer cat.Close()
+	db := cat.CatalogDB()
+
+	if _, err := db.Exec(
+		`INSERT INTO modules_data (Id, Name, ProjectId, SnapshotId) VALUES (?,?,?,?)`,
+		string(containerID), "SystemModule", "default", "s1",
+	); err != nil {
+		t.Fatalf("insert module: %v", err)
+	}
+
+	ctx := linter.NewLintContext(cat, reader)
+	ctx.SetExcludedModules([]string{"SystemModule"})
+
+	var count int
+	for range ctx.ScheduledEvents() {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0 events after exclusion, got %d", count)
+	}
+}
+
+func TestScheduledEvents_NilReader(t *testing.T) {
+	cat, err := catalog.NewFromFile(filepath.Join(t.TempDir(), "cat.db"))
+	if err != nil {
+		t.Fatalf("NewFromFile: %v", err)
+	}
+	defer cat.Close()
+
+	ctx := linter.NewLintContext(cat, nil)
+	var count int
+	for range ctx.ScheduledEvents() {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("expected 0 events with nil reader, got %d", count)
+	}
+}
+
+// TestStarlarkScheduledEventsBuiltin exercises the scheduled_events() Starlark builtin.
+const scheduledEventsRule = `
+RULE_ID = "TEST_SE001"
+RULE_NAME = "scheduled events builtin"
+DESCRIPTION = "exercises the scheduled_events() builtin"
+CATEGORY = "test"
+SEVERITY = "info"
+
+def check():
+    out = []
+    for se in scheduled_events():
+        out.append(violation(message = "se %s mf %s secs %d enabled %s" % (
+            se.qualified_name,
+            se.microflow_name,
+            se.interval_seconds,
+            "yes" if se.enabled else "no",
+        )))
+    return out
+`
+
+func TestStarlarkScheduledEventsBuiltin(t *testing.T) {
+	containerID := model.ID("mod-starlark")
+	mfID := model.ID("mf-starlark-uuid")
+
+	reader := &minimalReader{
+		listScheduledEvents: func() ([]*model.ScheduledEvent, error) {
+			return []*model.ScheduledEvent{{
+				ContainerID:  containerID,
+				Name:         "DailySE",
+				MicroflowID:  mfID,
+				Interval:     2,
+				IntervalType: "Day",
+				Enabled:      true,
+			}}, nil
+		},
+	}
+
+	cat, err := catalog.NewFromFile(filepath.Join(t.TempDir(), "cat.db"))
+	if err != nil {
+		t.Fatalf("NewFromFile: %v", err)
+	}
+	defer cat.Close()
+	db := cat.CatalogDB()
+
+	if _, err := db.Exec(
+		`INSERT INTO modules_data (Id, Name, ProjectId, SnapshotId) VALUES (?,?,?,?)`,
+		string(containerID), "Billing", "default", "s1",
+	); err != nil {
+		t.Fatalf("insert module: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO microflows_data (Id, Name, QualifiedName, ModuleName, MicroflowType, ProjectId, SnapshotId)
+		 VALUES (?,?,?,?,?,?,?)`,
+		string(mfID), "SUB_DailyJob", "Billing.SUB_DailyJob", "Billing", "Microflow", "default", "s1",
+	); err != nil {
+		t.Fatalf("insert microflow: %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "se_test.star")
+	if err := os.WriteFile(path, []byte(scheduledEventsRule), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rule, err := linter.LoadStarlarkRule(path)
+	if err != nil {
+		t.Fatalf("LoadStarlarkRule: %v", err)
+	}
+
+	ctx := linter.NewLintContext(cat, reader)
+	violations := rule.Check(ctx)
+
+	var msgs []string
+	for _, v := range violations {
+		msgs = append(msgs, v.Message)
+	}
+	joined := strings.Join(msgs, "\n")
+
+	for _, want := range []string{
+		"se Billing.DailySE",
+		"mf Billing.SUB_DailyJob",
+		"secs 172800", // 2 * 86400
+		"enabled yes",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("missing %q in violations:\n%s", want, joined)
+		}
+	}
+}


### PR DESCRIPTION
Adds a new `scheduled_events()` built-in to the linter's Starlark API so star rules can inspect scheduled event configuration (name, microflow, interval, enabled flag).

- Extends `LintReader` with `ListScheduledEvents()` (already implemented by MprBackend and MockBackend — no concrete changes needed there)
- Adds `ScheduledEvent` struct and `ScheduledEvents() iter.Seq` on `LintContext`; resolves module names from the catalog `modules` table and converts interval+type to seconds via `intervalToSeconds()`
- Registers `scheduled_events` builtin and adds `scheduledEventToStarlark` conversion in `starlark.go`