### PR TITLE
docs(microflows): add batch-commit-after-loop performance pattern

### DIFF
--- a/.claude/skills/mendix/write-microflows.md
+++ b/.claude/skills/mendix/write-microflows.md
@@ -435,6 +435,38 @@ end loop;
 - The loop variable type is **automatically derived** from the list type (e.g., `list of Test.Product` → `Test.Product`)
 - CHANGE statements inside loops use the derived type to resolve attribute names
 
+### Performance: Batch Commit After Loop
+
+**CRITICAL**: Do NOT commit inside a loop. Each `commit` inside a loop issues a separate database transaction, which causes N round-trips for N records and degrades performance significantly.
+
+❌ **INCORRECT — commit inside loop (N transactions):**
+```mdl
+loop $Binding in $BindingsList
+begin
+  $NewBatch = create BatteryOntology.MaterialBatch (BatchNo = $BatchNoObj/Value);
+  commit $NewBatch with events;  -- ❌ one DB transaction per record
+end loop;
+```
+
+✅ **CORRECT — create list before loop, commit once after:**
+```mdl
+$BatchList = create list of BatteryOntology.MaterialBatch;
+loop $Binding in $BindingsList
+begin
+  $NewBatch = create BatteryOntology.MaterialBatch (BatchNo = $BatchNoObj/Value);
+  add $NewBatch to $BatchList;   -- accumulate in memory
+end loop;
+commit $BatchList with events on error rollback;  -- ✅ single transaction
+```
+
+**Pattern:**
+1. Before the loop: `$XxxList = create list of Module.Entity;`
+2. Inside the loop: `add $NewXxx to $XxxList;` (replaces `commit`)
+3. After the loop: `commit $XxxList with events on error rollback;`
+
+This applies whenever the loop **creates** new objects. For loops that only **change** existing objects, the same pattern applies — accumulate changed objects in a list, commit the list once outside the loop.
+
+
 ## Object Operations
 
 ### CREATE Object


### PR DESCRIPTION
## Summary

Adds a **Performance: Batch Commit After Loop** section to `.claude/skills/mendix/write-microflows.md`, immediately after the existing `### LOOP Statements` notes.

## Problem

Committing inside a loop issues one database transaction per record — N round-trips for N objects. This is a common AI-generated antipattern that silently degrades performance at scale.

## Solution documented

Three-step pattern:

1. **Before loop**: `$XxxList = create list of Module.Entity;`
2. **Inside loop**: `add $NewXxx to $XxxList;` (replaces the per-iteration `commit`)
3. **After loop**: `commit $XxxList with events on error rollback;` — single transaction

Includes a clear ❌ / ✅ code example and a note that the same pattern applies when looping over *changes* to existing objects.

## Motivation

Discovered while fixing three import microflows (`ACT_ImportMaterialBatchesFromGraphStudio`, `ACT_ImportVehiclesFromGraphStudio`, `ACT_ImportWorkOrdersFromGraphStudio`) that each committed inside a SPARQL-result loop. Adding this to the skill file prevents the same antipattern from being generated in future projects.

## Diff

Pure addition — no existing content modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)