### PR TITLE
Fix GetRawUnit for v1 MPR files: convert UUID to GUID blob

### DIFF
--- a/sdk/mpr/reader_documents.go
+++ b/sdk/mpr/reader_documents.go
@@ -462,8 +462,9 @@ func (r *Reader) GetRawUnit(id model.ID) (map[string]any, error) {
 			return nil, fmt.Errorf("failed to read unit contents: %w", err)
 		}
 	} else {
-		// V1: Read from database
-		row := r.db.QueryRow("SELECT Contents FROM Unit WHERE UnitID = ?", string(id))
+		// V1: Read from database — convert UUID to GUID blob for the query
+		unitIDBlob := types.UUIDToBlob(string(id))
+		row := r.db.QueryRow("SELECT Contents FROM Unit WHERE UnitID = ?", unitIDBlob)
 		err = row.Scan(&contents)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read unit from database: %w", err)


### PR DESCRIPTION
## Summary

- `GetRawUnit()` in `sdk/mpr/reader_documents.go` passes the UUID string directly to SQLite on v1 MPRs, but `UnitID` is stored as a 16-byte GUID blob — the query never matches
- Added `types.UUIDToBlob()` conversion before the query, consistent with `getUnitByIDV1()` and `GetRawUnitBytes()` which already do this correctly

Fixes #705

## Impact

Any caller combining `ListPages()`/`ListSnippets()`/etc. with `GetRawUnit(id)` on a v1 project (Mendix < 10.18) gets `sql: no rows in result set` for every unit. This makes `GetRawUnit` unusable on v1 MPR files.

## Test plan

- Verified on real v1 MPR files (Mendix 9.24, 10.18, 10.24) ranging from 11MB to 111MB
- Confirmed `GetRawUnit` now returns valid BSON data for all page/snippet/layout units
- Confirmed v2 projects continue working unchanged (v2 path reads from mprcontents folder, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)