### PR TITLE
feat(new): add --container-runtime flag (parity with mxcli init)

### DIFF
--- a/cmd/mxcli/cmd_new.go
+++ b/cmd/mxcli/cmd_new.go
@@ -35,6 +35,7 @@ Examples:
 		mendixVersion, _ := cmd.Flags().GetString("version")
 		outputDir, _ := cmd.Flags().GetString("output-dir")
 		skipInit, _ := cmd.Flags().GetBool("skip-init")
+		containerRuntime, _ := cmd.Flags().GetString("container-runtime")
 
 		if mendixVersion == "" {
 			fmt.Fprintln(os.Stderr, "Error: --version is required (e.g., --version 11.8.0)")
@@ -118,6 +119,7 @@ Examples:
 		// Step 3: Initialize tooling
 		if !skipInit {
 			fmt.Printf("\nStep 3/4: Initializing AI tooling...\n")
+			initContainerRuntime = containerRuntime
 			initCmd.Run(initCmd, []string{absDir})
 		} else {
 			fmt.Printf("\nStep 3/4: Skipped (--skip-init)\n")
@@ -211,6 +213,7 @@ func init() {
 	newCmd.Flags().String("version", "", "Mendix version (e.g., 11.8.0) — required")
 	newCmd.Flags().String("output-dir", "", "Output directory (default: ./<app-name>)")
 	newCmd.Flags().Bool("skip-init", false, "Skip AI tooling initialization (mxcli init)")
+	newCmd.Flags().String("container-runtime", "docker", "Container runtime for devcontainer (docker or podman)")
 
 	rootCmd.AddCommand(newCmd)
 }


### PR DESCRIPTION
## Summary

- `mxcli new` always generated a Docker-based devcontainer because it called `initCmd.Run()` without forwarding the container runtime preference
- Adds `--container-runtime docker|podman` flag to `mxcli new`, matching the existing flag on `mxcli init`
- Sets `initContainerRuntime` before the internal `init` call so the generated `.devcontainer/` reflects the user's choice

## Test plan

- [ ] `mxcli new --help` shows `--container-runtime` flag
- [ ] `mxcli new MyApp --version 11.12.0 --container-runtime podman` generates `.devcontainer/devcontainer.json` with `MXCLI_CONTAINER_CLI=podman` and `runArgs`
- [ ] `mxcli new MyApp --version 11.12.0` (default) generates Docker-based devcontainer as before
- [ ] `podman build` on the generated Dockerfile succeeds

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)