### PR TITLE
fix(init): make devcontainer postCreateCommand robust on Podman-on-Windows (#742)

### DIFF
--- a/cmd/mxcli/tool_templates.go
+++ b/cmd/mxcli/tool_templates.go
@@ -312,7 +312,7 @@ func generateDevcontainerJSON(projectName, mprPath, containerRuntime string) str
   "containerEnv": {
     %s
   },
-  "postCreateCommand": "curl -fsSL https://claude.ai/install.sh | bash && if [ -f ./mxcli ] && file ./mxcli | grep -q Linux; then echo 'mxcli binary OK'; else ./mxcli setup mxcli --output ./mxcli 2>/dev/null || { ARCH=$(uname -m); [ \"$ARCH\" = x86_64 ] && ARCH=amd64; [ \"$ARCH\" = aarch64 ] && ARCH=arm64; curl -fsSL https://github.com/mendixlabs/mxcli/releases/latest/download/mxcli-linux-${ARCH} -o ./mxcli && chmod +x ./mxcli; }; fi",
+  "postCreateCommand": "curl -fsSL https://claude.ai/install.sh | bash && if [ -f ./mxcli ] && file ./mxcli | grep -q Linux; then echo 'mxcli binary OK'; else ./mxcli setup mxcli --output ./mxcli 2>/dev/null || { ARCH=$(uname -m); [ \"$ARCH\" = x86_64 ] && ARCH=amd64; [ \"$ARCH\" = aarch64 ] && ARCH=arm64; curl -fsSL https://github.com/mendixlabs/mxcli/releases/latest/download/mxcli-linux-${ARCH} -o ./mxcli && { chmod +x ./mxcli 2>/dev/null || true; }; }; fi",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -362,6 +362,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends wget apt-transp
        temurin-21-jdk \
        nodejs \
        postgresql-client \
+       file \
        kafkacat \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## What

Fixes two independent bugs in the devcontainer template generated by `mxcli init` / `mxcli new` (`cmd/mxcli/tool_templates.go`). Both fail the container's `postCreateCommand` (red error in VS Code) when the workspace is a **9p bind-mount from a Windows drive under Podman** — even though the container itself builds and `mxcli` runs fine.

Closes #742.

### Bug 1 — `file` not installed
`postCreateCommand` gates the "keep the committed Linux binary" fast-path on `file ./mxcli | grep -q Linux`, but `file` was never in the Dockerfile apt list → `command not found: file` → fast-path never taken, always re-downloads.
**Fix:** add `file` to the Dockerfile apt install list.

### Bug 2 — unguarded `chmod`
The download fallback ended in `... && chmod +x ./mxcli`. On 9p, Unix permission changes are `Operation not permitted`; the binary is already `-rwxrwxrwx`, but the non-zero exit failed the entire `postCreateCommand`.
**Fix:** `chmod +x ./mxcli 2>/dev/null || true`.

## Environment reproduced
Windows 11 + WSL2 + Podman 5.8.2, Mendix project on `C:\Mendix\...`, workspace via 9p, base image `mcr.microsoft.com/devcontainers/base:bookworm`, mxcli v0.14.0.

## Validation
- `make build` ✅
- `make test` ✅ (no new failures)
- `make lint` — Go lint ✅ (TS `lint-ts` step needs `bun`, not installed in this env; unrelated)
- **End-to-end:** ran `mxcli init --container-runtime podman` in a scratch dir → generated `devcontainer.json` parses as valid JSON, `postCreateCommand` ends with the guarded `{ chmod +x ./mxcli 2>/dev/null || true; }`, Dockerfile apt list contains `file`, and the extracted `postCreateCommand` passes `bash -n`.

## Notes
- Single source of truth: only `cmd/mxcli/tool_templates.go` holds this template. The repo's own `.devcontainer/*` uses a different (simpler) `postCreateCommand` and is unaffected.
- No test asserted on the `postCreateCommand` string, so nothing else changed.
- Follow-up enhancement (prebuilt ghcr.io image to avoid the ~5min local build) filed separately as #743.

🤖 Generated with [Claude Code](https://claude.com/claude-code)